### PR TITLE
Use bot's ID rather than email to filter out messages from itself

### DIFF
--- a/lib/flint.js
+++ b/lib/flint.js
@@ -1523,8 +1523,10 @@ Flint.prototype.onMessageCreated = function(message) {
           bot.emit('files', bot, trigger, bot.id);
         }
 
-        // if message is from bot...
-        if(trigger.personEmail === this.email) {
+        // check if message is from bot...
+        // using the bot's ID instead of the email guarantees this will work
+        // even if the bot's name changes (eg: mybot@sparkbot.io -> mybot@webex.bot)
+        if(trigger.personId === bot.person.id) {
           // ignore messages from bot
           return when(false);
         }


### PR DESCRIPTION
[On August 31st, 2018 all bots with the sparkbot.io domain name will be renamed with a webex.bot domain](https://developer.webex.com/apps.html).  Today in flint, the code compares the bot's email with the trigger email to filter out messages from itself.   If this code is running on August 31st the bot will start responding to its own messages.

A restart that day will fix the problem, but using a version of flint with this PR merged will avoid the problem all together.  The changes is to simply compare the trigger.id with the bot.person.id as well.  See this blog post: https://developer.webex.com/blog/blog-details-9878.html