### PR TITLE
Support events via sockets with webex sdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 ## News
 
+**6/21/19 Deploying behind a firewall:**
+
+* Cisco has recently introduced support in the Webex Javascript SDK which allows applications to register to receive the message, membership, and room events via a socket instead of via wehbhoks.   This allows applications to be deployed behind firewalls and removes the requirement that webex bots and integrations must expose a public IP address to receive events.   To take advantage of this in your flint applications simply remove the `webhookUrl` field from the configuration object passed to the flint constructor.   If this field is not set, flint will register to listen for these events instead of creating webhooks.
+  
 **6/21/18 IMPORTANT:**
 
 * On August 31st, 2018 all bots with the sparkbot.io domain name will be
@@ -81,9 +85,12 @@ flint.hears('/hello', function(bot, trigger) {
 });
 
 // define express path for incoming webhooks
+// This is not necessary if webhookUrl is not set in the config
 app.post('/flint', webhook(flint));
 
 // start express server
+// This is not necessary if webhookUrl is not set in the config
+// unless the bot uses express for other reasons
 var server = app.listen(config.port, function () {
   flint.debug('Flint listening on port %s', config.port);
 });
@@ -91,7 +98,7 @@ var server = app.listen(config.port, function () {
 // gracefully shutdown (ctrl-c)
 process.on('SIGINT', function() {
   flint.debug('stoppping...');
-  server.close();
+  server.close();   // remove if not using webhooks and express
   flint.stop().then(function() {
     process.exit();
   });
@@ -144,7 +151,7 @@ of the chained 'then' functions.
 * `commands` : The commands that are ran when the `phrase` is heard.
 
 ## Authentication
-The token used to authenticate Flint to the Spark API is passed as part of the
+The token used to authenticate Flint to the Spark (now Webex) API is passed as part of the
 options used when instantiating the Flint class. To change or update the
 token, use the Flint#setSparkToken() method.
 
@@ -192,7 +199,7 @@ flint.storageDriver(redisDriver('redis://localhost'));
 **When using "Bot Accounts" the major differences are:**
 
 * Webhooks for message:created only trigger when the Bot is mentioned by name
-* Unable to read messages in rooms using the Spark API
+* Unable to read messages in rooms using the Spark (now Webex) API
 
 **Differences with trigger.args using Flint with a "Bot Account":**
 
@@ -354,8 +361,8 @@ Options Object
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
 | token | <code>string</code> |  | Spark Token. |
-| webhookUrl | <code>string</code> |  | URL that is used for SPark API to send callbacks. |
-| [webhookSecret] | <code>string</code> |  | If specified, inbound webhooks are authorized before being processed. |
+| webhookUrl | <code>string</code> |  | URL that is used for Spark API to send callbacks.  If this field is omitted, flint will use the webex javascript sdk to register to listen for the events via websocket instead.|
+| [webhookSecret] | <code>string</code> |  | If specified, inbound webhooks are authorized before being processed. This configuration is ignored if `webhookUrl` is not set.|
 | [messageFormat] | <code>string</code> | <code>&quot;text&quot;</code> | Default Spark message format to use with bot.say(). |
 | [maxPageItems] | <code>number</code> | <code>50</code> | Max results that the paginator uses. |
 | [maxConcurrent] | <code>number</code> | <code>3</code> | Max concurrent sessions to the Spark API |
@@ -367,8 +374,8 @@ Options Object
 | [queueSize] | <code>number</code> | <code>10000</code> | Size of the buffer that holds outbound requests. |
 | [requeueSize] | <code>number</code> | <code>10000</code> | Size of the buffer that holds outbound re-queue requests. |
 | [id] | <code>string</code> | <code>&quot;random&quot;</code> | The id this instance of flint uses. |
-| [webhookRequestJSONLocation] | <code>string</code> | <code>&quot;body&quot;</code> | The property under the Request to find the JSON contents. |
-| [removeWebhooksOnStart] | <code>Boolean</code> | <code>true</code> | If you wish to have the bot remove all account webhooks when starting. |
+| [webhookRequestJSONLocation] | <code>string</code> | <code>&quot;body&quot;</code> | The property under the Request to find the JSON contents. This configuration is ignored if `webhookUrl` is not set. |
+| [removeWebhooksOnStart] | <code>Boolean</code> | <code>true</code> | If you wish to have the bot remove all account webhooks when starting. This configuration is ignored if `webhookUrl` is not set. |
 
 <a name="Flint+setSparkToken"></a>
 

--- a/docs/header.md
+++ b/docs/header.md
@@ -4,6 +4,10 @@
 
 ## News
 
+**6/21/19 Deploying behind a firewall:**
+
+* Cisco has recently introduced support in the Webex Javascript SDK which allows applications to register to receive the message, membership, and room events via a socket instead of via wehbhoks.   This allows applications to be deployed behind firewalls and removes the requirement that webex bots and integrations must expose a public IP address to receive events.   To take advantage of this in your flint applications simply remove the `webhookUrl` field from the configuration object passed to the flint constructor.   If this field is not set, flint will register to listen for these events instead of creating webhooks.
+
 **6/21/18 IMPORTANT:**
 
 * On August 31st, 2018 all bots with the sparkbot.io domain name will be

--- a/lib/flint.js
+++ b/lib/flint.js
@@ -231,34 +231,7 @@ Flint.prototype.stop = function() {
   // if not stopped...
   if(this.active) {
 
-    return this.getWebhooks()
-      // get webhooks
-      .then(webhooks => {
-
-        // remove all webhooks on stop
-        if(!this.options.removeWebhooksOnStart) {
-          var webhooksToRemove = _.filter(webhooks, webhook => {
-            return (webhook.name == u.base64encode(this.options.webhookUrl.split('/')[2] + ' ' + this.email));
-          });
-
-          if(webhooksToRemove instanceof Array && webhooksToRemove.length > 0) {
-            return when.map(webhooksToRemove, webhook => this.spark.webhookRemove(webhook.id))
-              .then(() => when(true))
-              .catch(() => when(true));
-          } else {
-            return when(true);
-          }
-        }
-
-        // else, only remove webhooks this app created
-        else {
-          return when.map(webhooks, webhook => this.spark.webhookRemove(webhook.id))
-            .then(() => when(true))
-            .catch(() => when(true));
-        }
-
-      })
-
+    return cleanupListeners(this)
       .then(() => {
         if(this.auditInterval) clearInterval(this.auditInterval);
 
@@ -335,46 +308,57 @@ Flint.prototype.start = function() {
         return when(person);
       })
 
-      // get webhooks
-      .then(person => this.getWebhooks())
-
-      // process webhooks
-      .then(webhooks => {
-
-        // remove only webhooks this app created
-        if(!this.options.removeWebhooksOnStart) {
-
-          var webhooksToRemove = _.filter(webhooks, webhook => {
-            return (webhook.name == u.base64encode(this.options.webhookUrl.split('/')[2] + ' ' + this.email));
-          });
-
-          if(webhooksToRemove instanceof Array && webhooksToRemove.length > 0) {
-            return when.map(webhooksToRemove, webhook => this.spark.webhookRemove(webhook.id));
-          } else {
-            return when(true);
-          }
-        }
-
-       // else, remove all webhooks on start
-        else {
-          return when.map(webhooks, webhook => this.spark.webhookRemove(webhook.id));
-        }
-      })
-
+      // Configure webhooks or websockets
       .then(() => {
-        if(this.options.webhookUrl) {
-          return this.spark.webhookAdd('all', 'all', u.base64encode(this.options.webhookUrl.split('/')[2] + ' ' + this.email))
-            .then(webhook => {
-              this.webhook = webhook;
-              return when(webhook);
+        if (this.options.webhookUrl) {
+          // get webhooks
+          this.getWebhooks()
+
+            // process webhooks
+            .then(webhooks => {
+
+              // remove only webhooks this app created
+              if(!this.options.removeWebhooksOnStart) {
+
+                var webhooksToRemove = _.filter(webhooks, webhook => {
+                  return (webhook.name == u.base64encode(this.options.webhookUrl.split('/')[2] + ' ' + this.email));
+                });
+
+                if(webhooksToRemove instanceof Array && webhooksToRemove.length > 0) {
+                  return when.map(webhooksToRemove, webhook => this.spark.webhookRemove(webhook.id));
+                } else {
+                  return when(true);
+                }
+              }
+
+              // else, remove all webhooks on start
+              else {
+                return when.map(webhooks, webhook => this.spark.webhookRemove(webhook.id));
+              }
             })
-            .catch(() => {
-              this.webhook = false;
-              return when(false);
+
+            .then(() => {
+              if(this.options.webhookUrl) {
+                return this.spark.webhookAdd('all', 'all', u.base64encode(this.options.webhookUrl.split('/')[2] + ' ' + this.email))
+                  .then(webhook => {
+                    this.webhook = webhook;
+                    return when(webhook);
+                  })
+                  .catch(() => {
+                    this.webhook = false;
+                    return when(false);
+                  });
+              } else {
+                this.webhook = false;
+                return when(false);
+              }
             });
         } else {
-          this.webhook = false;
-          return when(false);
+          // There was no webhookUrl specified so we will use websockets instead
+          var webhook = require('./webhook');
+          let Websocket = require('./websocket');
+          this.websocket = new Websocket(this, webhook);
+          return this.websocket.init();
         }
       })
 
@@ -2040,3 +2024,42 @@ Flint.prototype.use = function(pluginPath) {
 };
 
 module.exports = Flint;
+
+function cleanupListeners(flint) {
+  // Cleanup webhooks or websockets
+  if (flint.options.webhookUrl) {
+    return flint.getWebhooks()
+      // get webhooks
+      .then(webhooks => {
+
+        // remove all webhooks on stop
+        if(!flint.options.removeWebhooksOnStart) {
+          var webhooksToRemove = _.filter(webhooks, webhook => {
+            return (webhook.name == u.base64encode(flint.options.webhookUrl.split('/')[2] + ' ' + flint.email));
+          });
+
+          if(webhooksToRemove instanceof Array && webhooksToRemove.length > 0) {
+            return when.map(webhooksToRemove, webhook => flint.spark.webhookRemove(webhook.id))
+              .then(() => when(true))
+              .catch(() => when(true));
+          } else {
+            return when(true);
+          }
+        }
+
+        // else, only remove webhooks this app created
+        else {
+          return when.map(webhooks, webhook => flint.spark.webhookRemove(webhook.id))
+            .then(() => when(true))
+            .catch(() => when(true));
+        }
+
+      });
+  } else {
+    return flint.websocket.cleanup()
+      .then(() => {
+        delete flint.websocket;
+        return when(true);
+      });
+  }
+}

--- a/lib/process-event.js
+++ b/lib/process-event.js
@@ -1,0 +1,151 @@
+'use strict';
+
+var when = require('when');
+
+/**
+ * Processes an inbound Webex event.
+ * This can be called by either the webhook or websocket handler.
+ * @function
+ * @private
+ * @param {Object} flint - The flint object this function applies to.
+ * @param {Object} body - The body of the event being processed
+ * @param {String} name - The name of the webhook, if a webhook is being processed
+ */
+function processEvent(flint, body, name = '') {
+  if(!flint.active) {
+    return when(true);
+  }
+
+  // get event content
+  var name = name ? name : body.name;
+  var resource = body.resource;
+  var event = body.event;
+  var data = body.data;
+  var roomId = body.filter ? body.filter.split('=')[1] : null;
+
+  // validate event is bound for this instance of flint
+  if(name !== flint.webhook.name || (typeof flint.webhook.roomId !== 'undefined' && flint.webhook.roomId !== roomId)) {
+    return when(true);
+  }
+
+  if(typeof resource !== 'string' || typeof event !== 'string') {
+    flint.debug('Can not determine webhook type');
+    return when(true);
+  }
+
+  // rooms
+  if(resource === 'rooms') {
+    return flint.getRoom(data.id)
+      .then(room => {
+
+        // set room title for rooms with none set (api bug?)
+        if(room.title == '') {
+          room.title = 'Default title';
+        }
+
+        // room created
+        if(event === 'created') {
+          flint.emit('roomCreated', room, flint.id);
+
+          return flint.onRoomCreated(room)
+            .catch(err => {
+              flint.debug(err.stack);
+              return when(true);
+            });
+        }
+
+        // room updated
+        if(event === 'updated') {
+          flint.emit('roomUpdated', room, flint.id);
+
+          return flint.onRoomUpdated(room)
+            .catch(err => {
+              flint.debug(err.stack);
+              return when(true);
+            });
+        }
+
+      })
+      .catch(() => {
+        return when(true);
+      });
+  }
+
+  // memberships
+  if(resource === 'memberships') {
+
+    // membership created
+    if(event === 'created') {
+      return flint.getMembership(data.id)
+        .then(membership => {
+          flint.emit('membershipCreated', membership, flint.id);
+
+          return flint.onMembershipCreated(membership)
+            .catch(err => {
+              flint.debug(err.stack);
+              return when(true);
+            });
+        })
+        .catch(() => {
+          return when(true);
+        });
+    }
+
+    // membership updated
+    if(event === 'updated') {
+      return flint.getMembership(data.id)
+        .then(membership => {
+          flint.emit('membershipUpdated', membership, flint.id);
+
+          return flint.onMembershipUpdated(membership)
+            .catch(err => {
+              flint.debug(err.stack);
+              return when(true);
+            });
+        })
+        .catch(() => {
+          return when(true);
+        });
+    }
+
+    // membership deleted
+    if(event === 'deleted') {
+      flint.emit('membershipDeleted', data, flint.id);
+
+      return flint.onMembershipDeleted(data)
+        .catch(err => {
+          flint.debug(err.stack);
+          return when(true);
+        });
+    }
+
+  }
+
+  // messages
+  if(resource === 'messages') {
+    // membership created
+    if(event === 'created') {
+      return flint.getMessage(data.id)
+        .then(message => {
+          flint.emit('messageCreated', message, flint.id);
+
+          return flint.onMessageCreated(message)
+            .catch(err => {
+              flint.debug(err.stack);
+              return when(true);
+            });
+        })
+        .catch(() => {
+          return when(true);
+        });
+    }
+
+    // message deleted
+    if(event === 'deleted') {
+      flint.emit('messageDeleted', data, flint.id);
+      return when(true);
+    }
+  }
+}
+
+module.exports = processEvent;

--- a/lib/webhook.js
+++ b/lib/webhook.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var when = require('when');
+var processEvent = require('./process-event'); 
 
 /**
  * Processes a inbound Spark API webhook.
@@ -38,141 +39,8 @@ function Webhook(flint) {
       return when(true);
     }
 
-    if(!flint.active) {
-      return when(true);
-    }
+    return processEvent(flint, body);
 
-    // get webhook content
-    var id = body.id;
-    var name = body.name;
-    var resource = body.resource;
-    var event = body.event;
-    var data = body.data;
-    var roomId = body.filter ? body.filter.split('=')[1] : null;
-
-    // validate webbhook is bound for this instance of flint
-    if(name !== flint.webhook.name || (typeof flint.webhook.roomId !== 'undefined' && flint.webhook.roomId !== roomId)) {
-      return when(true);
-    }
-
-    if(typeof resource !== 'string' || typeof event !== 'string') {
-      flint.debug('Can not determine webhook type');
-      return when(true);
-    }
-
-    // rooms
-    if(resource === 'rooms') {
-      return flint.getRoom(data.id)
-        .then(room => {
-
-          // set room title for rooms with none set (api bug?)
-          if(room.title == '') {
-            room.title = 'Default title';
-          }
-
-          // room created
-          if(event === 'created') {
-            flint.emit('roomCreated', room, flint.id);
-
-            return flint.onRoomCreated(room)
-              .catch(err => {
-                flint.debug(err.stack);
-                return when(true);
-              });
-          }
-
-          // room updated
-          if(event === 'updated') {
-            flint.emit('roomUpdated', room, flint.id);
-
-            return flint.onRoomUpdated(room)
-              .catch(err => {
-                flint.debug(err.stack);
-                return when(true);
-              });
-          }
-
-        })
-        .catch(() => {
-          return when(true);
-        });
-    }
-
-    // memberships
-    if(resource === 'memberships') {
-
-      // membership created
-      if(event === 'created') {
-        return flint.getMembership(data.id)
-          .then(membership => {
-            flint.emit('membershipCreated', membership, flint.id);
-
-            return flint.onMembershipCreated(membership)
-              .catch(err => {
-                flint.debug(err.stack);
-                return when(true);
-              });
-          })
-          .catch(() => {
-            return when(true);
-          });
-      }
-
-      // membership updated
-      if(event === 'updated') {
-        return flint.getMembership(data.id)
-          .then(membership => {
-            flint.emit('membershipUpdated', membership, flint.id);
-
-            return flint.onMembershipUpdated(membership)
-              .catch(err => {
-                flint.debug(err.stack);
-                return when(true);
-              });
-          })
-          .catch(() => {
-            return when(true);
-          });
-      }
-
-      // membership deleted
-      if(event === 'deleted') {
-        flint.emit('membershipDeleted', data, flint.id);
-
-        return flint.onMembershipDeleted(data)
-          .catch(err => {
-            flint.debug(err.stack);
-            return when(true);
-          });
-      }
-
-    }
-
-    // messages
-    if(resource === 'messages') {
-      // membership created
-      if(event === 'created') {
-        return flint.getMessage(data.id)
-          .then(message => {
-            flint.emit('messageCreated', message, flint.id);
-
-            return flint.onMessageCreated(message)
-              .catch(err => {
-                flint.debug(err.stack);
-                return when(true);
-              });
-          })
-          .catch(() => {
-            return when(true);
-          });
-      }
-
-      // message deleted
-      if(event === 'deleted') {
-        flint.emit('messageDeleted', data, flint.id);
-        return when(true);
-      }
-    }
   }; // end of return function...
 }
 

--- a/lib/websocket.js
+++ b/lib/websocket.js
@@ -1,0 +1,86 @@
+'use strict';
+
+var when = require('when');
+var Webex = require('webex'); 
+var processEvent = require('./process-event'); 
+
+/**
+ * A class to register for webex teams messaging events to be delivered
+ * via socket using the webex SDK
+ * 
+ * This class will register to listen to the events.  When an event
+ * is received it will call the webhook handler with the event payload
+ * 
+ * This approach allows bot developers to deploy bots behind a firewall
+ * without requiring a public IP address in order to receive webhooks
+ * 
+ * @function
+ * @private
+ * @param {Object} flint - The flint object this function applies to.
+ * @param {Object} webhook - The webhook handler object for this instance
+ * @returns {Object}
+ *
+ */
+function Websocket(flint, webhook) {
+  this.flint = flint;
+  this.webhook = webhook;
+  // Todo make this more like the traditional flint "name"
+  // B64 encoding of URL and bot name...
+  this.name = 'webex sdk socket event';
+  flint.webhook.name = this.name;
+}
+
+Websocket.prototype.init = function() {
+  this.flint.webex = Webex.init({
+    credentials: {
+      access_token: this.flint.options.token
+    }
+  });
+
+  if (!((this.flint.webex) && (this.flint.webex.canAuthorize))) {
+    console.error('Unable to intiatize Webex SDK for events');
+    return when(false);
+  }
+
+  // register for message, membership and room events
+  let messagesPromise = this.flint.webex.messages.listen();
+  let membershipsPromise = this.flint.webex.memberships.listen();
+  let roomsPromise = this.flint.webex.rooms.listen();
+
+  return Promise.all([messagesPromise, membershipsPromise, roomsPromise])
+    .then(() => {
+      this.flint.webex.messages.on('created', (event) => processEvent(this.flint, event, this.name));
+      this.flint.webex.messages.on('deleted', (event) => processEvent(this.flint, event, this.name));
+      this.flint.webex.memberships.on('created', (event) => processEvent(this.flint, event, this.name));
+      this.flint.webex.memberships.on('deleted', (event) => processEvent(this.flint, event, this.name));
+      this.flint.webex.memberships.on('updated', (event) => processEvent(this.flint, event, this.name));
+      this.flint.webex.rooms.on('created', (event) => processEvent(this.flint, event, this.name));
+      this.flint.webex.rooms.on('updated', (event) => processEvent(this.flint, event, this.name));
+      console.log('Listening for webex teams events...');
+      return when(true);
+    })
+    .catch((err) => {
+      console.error(`error listening for webex teams events: ${err}`);
+      return Promise.reject(err);
+    });
+};
+
+Websocket.prototype.cleanup = function() {
+  // register for message, membership and room events
+  this.flint.webex.messages.stopListening();
+  this.flint.webex.memberships.stopListening();
+  this.flint.webex.rooms.stopListening();
+
+  this.flint.webex.messages.off('created');
+  this.flint.webex.messages.off('deleted');
+  this.flint.webex.memberships.off('created');
+  this.flint.webex.memberships.off('deleted');
+  this.flint.webex.memberships.off('updated');
+  this.flint.webex.rooms.off('created');
+  this.flint.webex.rooms.off('updated');
+  console.log('Stopped istening for webex teams events...');
+  return when(true);
+};
+
+module.exports = Websocket;
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,739 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@webex/common": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@webex/common/-/common-1.61.1.tgz",
+      "integrity": "sha512-q/vv+yrEQR4FJLoEjSxEj1pWciycgZZ3rAr3BhogXkVIzCsNt+BWuacQlS/RdQsCuTn9arrkKxH+Gt9h9ibz4w==",
+      "requires": {
+        "@webex/common": "1.61.1",
+        "babel-runtime": "^6.23.0",
+        "backoff": "^2.5.0",
+        "core-decorators": "^0.20.0",
+        "envify": "^4.1.0",
+        "lodash": "^4.17.11",
+        "urlsafe-base64": "^1.0.0"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+        }
+      }
+    },
+    "@webex/common-evented": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@webex/common-evented/-/common-evented-1.61.1.tgz",
+      "integrity": "sha512-wP/MfUWgdCQ+nm4A8yr1EiYU1fZ6KcJgVSomHguW98nm11BzKc5too4WAJ+yE+u9K2Vijra84Uqd8vILIpGjpg==",
+      "requires": {
+        "@webex/common": "1.61.1",
+        "babel-runtime": "^6.23.0",
+        "envify": "^4.1.0"
+      }
+    },
+    "@webex/common-timers": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@webex/common-timers/-/common-timers-1.61.1.tgz",
+      "integrity": "sha512-huWehXHVTcj+IgTzuvhwz9Jnno4vnPp77l3lDxf6zEAvsWnqWPLj8X87MTnicrDckxiUNtegPbankr3MgfWZAA==",
+      "requires": {
+        "envify": "^4.1.0"
+      }
+    },
+    "@webex/helper-html": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@webex/helper-html/-/helper-html-1.61.1.tgz",
+      "integrity": "sha512-4viUVxovqtzUHjALODhJJ1t5QU3CGnJEc9ywZUXrpzu6gZ8Xig0/ryuQ3KnvmivzwFmdn1EIG4XDqJpDn2o1Qg==",
+      "requires": {
+        "babel-runtime": "^6.23.0",
+        "envify": "^4.1.0",
+        "lodash": "^4.17.11"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+        }
+      }
+    },
+    "@webex/helper-image": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@webex/helper-image/-/helper-image-1.61.1.tgz",
+      "integrity": "sha512-k5yb9UvfHmEPAg8QzNbTMoP8F2AuEhiWGOYzesxigY7kkKWg2CE3g5ommAgxX42JVyi1kVSLT2enWpgUYl3AyQ==",
+      "requires": {
+        "@webex/http-core": "1.61.1",
+        "babel-runtime": "^6.23.0",
+        "envify": "^4.1.0",
+        "exif": "^0.6.0",
+        "gm": "^1.23.0",
+        "lodash": "^4.17.11",
+        "mime-types": "^2.1.15"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+        }
+      }
+    },
+    "@webex/http-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@webex/http-core/-/http-core-1.61.1.tgz",
+      "integrity": "sha512-ThgrjOQhLIS13V65sdRJa0uDb5PYy6JtGIyr/ktNcJDPr0fExrf+mV1TNZIXRkuPY5o13JbuRPeWDjj47HoCig==",
+      "requires": {
+        "@webex/common": "1.61.1",
+        "babel-runtime": "^6.23.0",
+        "envify": "^4.1.0",
+        "file-type": "^3.9.0",
+        "global": "^4.3.1",
+        "is-function": "^1.0.1",
+        "lodash": "^4.17.11",
+        "parse-headers": "^2.0.1",
+        "qs": "^6.5.1",
+        "request": "^2.81.0",
+        "xtend": "^4.0.1"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+        },
+        "aws-sign2": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+          "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+        },
+        "aws4": {
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
+          "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
+        },
+        "caseless": {
+          "version": "0.12.0",
+          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+          "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+        },
+        "extend": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+          "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+        },
+        "form-data": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+          "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.6",
+            "mime-types": "^2.1.12"
+          }
+        },
+        "har-validator": {
+          "version": "5.1.3",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+          "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+          "requires": {
+            "ajv": "^6.5.5",
+            "har-schema": "^2.0.0"
+          }
+        },
+        "http-signature": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+          "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+          "requires": {
+            "assert-plus": "^1.0.0",
+            "jsprim": "^1.2.2",
+            "sshpk": "^1.7.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+        },
+        "mime-db": {
+          "version": "1.40.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
+          "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA=="
+        },
+        "mime-types": {
+          "version": "2.1.24",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
+          "integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
+          "requires": {
+            "mime-db": "1.40.0"
+          }
+        },
+        "oauth-sign": {
+          "version": "0.9.0",
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+          "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+        },
+        "qs": {
+          "version": "6.7.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+          "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
+        },
+        "request": {
+          "version": "2.88.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
+          "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+          "requires": {
+            "aws-sign2": "~0.7.0",
+            "aws4": "^1.8.0",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.6",
+            "extend": "~3.0.2",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.3.2",
+            "har-validator": "~5.1.0",
+            "http-signature": "~1.2.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.19",
+            "oauth-sign": "~0.9.0",
+            "performance-now": "^2.1.0",
+            "qs": "~6.5.2",
+            "safe-buffer": "^5.1.2",
+            "tough-cookie": "~2.4.3",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.3.2"
+          },
+          "dependencies": {
+            "qs": {
+              "version": "6.5.2",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+              "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+            }
+          }
+        },
+        "tough-cookie": {
+          "version": "2.4.3",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+          "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+          "requires": {
+            "psl": "^1.1.24",
+            "punycode": "^1.4.1"
+          }
+        },
+        "tunnel-agent": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+          "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+          "requires": {
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "uuid": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+        }
+      }
+    },
+    "@webex/internal-plugin-conversation": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-conversation/-/internal-plugin-conversation-1.61.1.tgz",
+      "integrity": "sha512-upyZPjO/fPZvv+tartQs0cTmtiRxa9hPFGiCqnwYd23J7c8iV6R7gvNjfBkG0RYJG5MvAyAXKQeBjXkKpRgzqg==",
+      "requires": {
+        "@webex/common": "1.61.1",
+        "@webex/helper-html": "1.61.1",
+        "@webex/helper-image": "1.61.1",
+        "@webex/internal-plugin-encryption": "1.61.1",
+        "@webex/internal-plugin-user": "1.61.1",
+        "@webex/webex-core": "1.61.1",
+        "babel-runtime": "^6.23.0",
+        "envify": "^4.1.0",
+        "lodash": "^4.17.11",
+        "uuid": "^3.2.1"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+        },
+        "uuid": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+        }
+      }
+    },
+    "@webex/internal-plugin-encryption": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-encryption/-/internal-plugin-encryption-1.61.1.tgz",
+      "integrity": "sha512-cRMbd54PwtgjuRh2Shumi9s1NtJn+ToEGSMtCL+9pIdSRG7oHPOUJVTaXyqb6H0ENyW+NzhLdfJ/QLEacLmthQ==",
+      "requires": {
+        "@webex/common": "1.61.1",
+        "@webex/common-timers": "1.61.1",
+        "@webex/http-core": "1.61.1",
+        "@webex/internal-plugin-mercury": "1.61.1",
+        "@webex/internal-plugin-wdm": "1.61.1",
+        "@webex/webex-core": "1.61.1",
+        "babel-runtime": "^6.23.0",
+        "envify": "^4.1.0",
+        "lodash": "^4.17.11",
+        "node-jose": "^0.11.0",
+        "node-kms": "^0.3.2",
+        "node-scr": "^0.2.2"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+        }
+      }
+    },
+    "@webex/internal-plugin-feature": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-feature/-/internal-plugin-feature-1.61.1.tgz",
+      "integrity": "sha512-oNY+JkSPpZwlgpilVA6ANf7ztAfa3+zR0WfX0v0C9NEjxa7QDm9LuzwHbFcgom4ehiXa9zLSJtM2mpt7TELRgA==",
+      "requires": {
+        "@webex/internal-plugin-wdm": "1.61.1",
+        "@webex/webex-core": "1.61.1",
+        "babel-runtime": "^6.23.0",
+        "envify": "^4.1.0",
+        "lodash": "^4.17.11"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+        }
+      }
+    },
+    "@webex/internal-plugin-locus": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-locus/-/internal-plugin-locus-1.61.1.tgz",
+      "integrity": "sha512-cH7BQ1vjiHf4rZtbQG4X+2PEZPNGEYRuRIsD9k30a0wG4IRbMh/1+M8TqWdK96Bxf54E6Up6MUL6LPqN4gC6Hw==",
+      "requires": {
+        "@webex/internal-plugin-mercury": "1.61.1",
+        "@webex/webex-core": "1.61.1",
+        "babel-runtime": "^6.23.0",
+        "envify": "^4.1.0",
+        "lodash": "^4.17.11",
+        "uuid": "^3.2.1"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+        },
+        "uuid": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+        }
+      }
+    },
+    "@webex/internal-plugin-mercury": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-mercury/-/internal-plugin-mercury-1.61.1.tgz",
+      "integrity": "sha512-cKXLETb2hc4sVew8p/0TsXEH/Cv7R70Pc1ZirO1/5N9EkzlrcQnoSD3OOu5uGbGS9Idq3BGWEY0ky+TuABjZRg==",
+      "requires": {
+        "@webex/common": "1.61.1",
+        "@webex/common-timers": "1.61.1",
+        "@webex/internal-plugin-feature": "1.61.1",
+        "@webex/internal-plugin-metrics": "1.61.1",
+        "@webex/internal-plugin-wdm": "1.61.1",
+        "@webex/webex-core": "1.61.1",
+        "babel-runtime": "^6.23.0",
+        "backoff": "^2.5.0",
+        "envify": "^4.1.0",
+        "lodash": "^4.17.11",
+        "uuid": "^3.2.1",
+        "ws": "^4.0.0"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+        },
+        "uuid": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+        }
+      }
+    },
+    "@webex/internal-plugin-metrics": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-metrics/-/internal-plugin-metrics-1.61.1.tgz",
+      "integrity": "sha512-e8YXeJm0sF2/rsMLdri3bnuzRA56m9dtASpv3vnBGJ4Mr55Mr20LfdrJRPY00eR5E2FlrddhnnYY8OI5e+u0CA==",
+      "requires": {
+        "@webex/common": "1.61.1",
+        "@webex/common-timers": "1.61.1",
+        "@webex/internal-plugin-wdm": "1.61.1",
+        "@webex/webex-core": "1.61.1",
+        "babel-runtime": "^6.23.0",
+        "envify": "^4.1.0"
+      }
+    },
+    "@webex/internal-plugin-user": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-user/-/internal-plugin-user-1.61.1.tgz",
+      "integrity": "sha512-Ly73BDYxXrmUZsFDyKUrBr+HALbe5y4Mcm8NpihFrX62aBXRvLagDjUp8Xj50QHNw8DSq8UNaXwiW1Ae7QjQ0w==",
+      "requires": {
+        "@webex/common": "1.61.1",
+        "@webex/internal-plugin-wdm": "1.61.1",
+        "@webex/webex-core": "1.61.1",
+        "babel-runtime": "^6.23.0",
+        "envify": "^4.1.0",
+        "lodash": "^4.17.11"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+        }
+      }
+    },
+    "@webex/internal-plugin-wdm": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-wdm/-/internal-plugin-wdm-1.61.1.tgz",
+      "integrity": "sha512-mWZyYc0z+/71RBdL1syN9H9DK0q+/a8EF+DJMLQBNqzVDB37etBCdffG1rgVxZwCZdOBNdvKuA4KYz67ON0JCA==",
+      "requires": {
+        "@webex/common": "1.61.1",
+        "@webex/common-timers": "1.61.1",
+        "@webex/http-core": "1.61.1",
+        "@webex/webex-core": "1.61.1",
+        "ampersand-collection": "^2.0.2",
+        "ampersand-state": "^5.0.2",
+        "babel-runtime": "^6.23.0",
+        "envify": "^4.1.0",
+        "lodash": "^4.17.11"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+        }
+      }
+    },
+    "@webex/media-engine-webrtc": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@webex/media-engine-webrtc/-/media-engine-webrtc-1.61.1.tgz",
+      "integrity": "sha512-z++ab8SSDXdCWtBII/iu3UqEKYK4nGxr1GxAx/ieXlSdwAmUwDabojeXSBKpq5fPuPP1ndCSxbN8SA178DOqVQ==",
+      "requires": {
+        "@webex/common": "1.61.1",
+        "@webex/common-evented": "1.61.1",
+        "ampersand-events": "^2.0.2",
+        "babel-runtime": "^6.23.0",
+        "bowser": "1.9.4",
+        "core-decorators": "^0.20.0",
+        "envify": "^4.1.0",
+        "lodash": "^4.17.11",
+        "lodash-decorators": "^4.3.4",
+        "sdp-transform": "^2.4.0",
+        "webrtc-adapter": "^6.1.0"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+        }
+      }
+    },
+    "@webex/plugin-authorization": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-authorization/-/plugin-authorization-1.61.1.tgz",
+      "integrity": "sha512-ANiqm5Pm/4nq4CwEgUyN4I2UXMIgwSxKF8BQzrdNUxXQcRzU4j/EPpiDVrXjxazeEP34bKzfN8uOSER01JUMuA==",
+      "requires": {
+        "@webex/plugin-authorization-browser": "1.61.1",
+        "@webex/plugin-authorization-node": "1.61.1",
+        "envify": "^4.1.0"
+      }
+    },
+    "@webex/plugin-authorization-browser": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-authorization-browser/-/plugin-authorization-browser-1.61.1.tgz",
+      "integrity": "sha512-jU3uQhzETCKdaSaOFb/ysN4iXxcLHyXTQHzb52UWAe4UPucpzIKZ/Gz1UM0FjfpQoAfj++xqnH9K6wqJvijGQg==",
+      "requires": {
+        "@webex/common": "1.61.1",
+        "@webex/internal-plugin-wdm": "1.61.1",
+        "@webex/webex-core": "1.61.1",
+        "babel-runtime": "^6.23.0",
+        "envify": "^4.1.0",
+        "lodash": "^4.17.11",
+        "uuid": "^3.2.1"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+        },
+        "uuid": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+        }
+      }
+    },
+    "@webex/plugin-authorization-node": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-authorization-node/-/plugin-authorization-node-1.61.1.tgz",
+      "integrity": "sha512-+u2GXXGWG4fwN/yuVEHUAgzt94BDsbN5559hMtf2kVzK9kQMm63DQPgXnf5d3albMjaxFz8qnQzFhDtGrAPU9A==",
+      "requires": {
+        "@webex/common": "1.61.1",
+        "@webex/internal-plugin-wdm": "1.61.1",
+        "@webex/webex-core": "1.61.1",
+        "babel-runtime": "^6.23.0",
+        "envify": "^4.1.0"
+      }
+    },
+    "@webex/plugin-logger": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-logger/-/plugin-logger-1.61.1.tgz",
+      "integrity": "sha512-cY83q4HmXB9DMWU464WtP2BlYYYh8irCSC8q25dXc0Z2wNSWABSEE8vtqzCTjU7u1rIGaIsXW5DVcHi2KJH2Jw==",
+      "requires": {
+        "@webex/common": "1.61.1",
+        "@webex/webex-core": "1.61.1",
+        "babel-runtime": "^6.23.0",
+        "envify": "^4.1.0",
+        "lodash": "^4.17.11"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+        }
+      }
+    },
+    "@webex/plugin-memberships": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-memberships/-/plugin-memberships-1.61.1.tgz",
+      "integrity": "sha512-E1NUjfDUZ2YxKIrRRqrYUfrO9OIisdXoVNroAp8+To6aBHV5zcjWyRkybB8Waxm80JSlYmcvRiZwfwQELR34JA==",
+      "requires": {
+        "@webex/common": "1.61.1",
+        "@webex/internal-plugin-conversation": "1.61.1",
+        "@webex/internal-plugin-mercury": "1.61.1",
+        "@webex/webex-core": "1.61.1",
+        "babel-runtime": "^6.23.0",
+        "debug": "^3.1.0",
+        "envify": "^4.1.0",
+        "lodash": "^4.17.11"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
+    },
+    "@webex/plugin-messages": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-messages/-/plugin-messages-1.61.1.tgz",
+      "integrity": "sha512-C1diWsFuH2EkM5BG6RKtMcdAqAnZC0QEiQ8Xtk/xl+dLEdlFwp94loyxmpwfoeuldj03kSle7tLp+ySbRnZgzg==",
+      "requires": {
+        "@webex/common": "1.61.1",
+        "@webex/internal-plugin-conversation": "1.61.1",
+        "@webex/internal-plugin-mercury": "1.61.1",
+        "@webex/webex-core": "1.61.1",
+        "babel-runtime": "^6.23.0",
+        "debug": "^3.1.0",
+        "envify": "^4.1.0",
+        "lodash": "^4.17.11"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
+    },
+    "@webex/plugin-people": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-people/-/plugin-people-1.61.1.tgz",
+      "integrity": "sha512-9g+6Rdfxd2gLZNfgGwUiFDoC2lb3NzWB4pqC6zM44QYU4pWd7hFYoC0XnJXxYhieJfEoQTaDXJ6ohXNgkVh7Bg==",
+      "requires": {
+        "@webex/common": "1.61.1",
+        "@webex/webex-core": "1.61.1",
+        "babel-runtime": "^6.23.0",
+        "envify": "^4.1.0"
+      }
+    },
+    "@webex/plugin-phone": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-phone/-/plugin-phone-1.61.1.tgz",
+      "integrity": "sha512-cT412OrJZWMu7j6SLogZv3z2G2N+slLWJPm7Y2UD8AtvqslUKsxcIO4TKc0JeLrkzMXTmC1HmOfloTcsfpJIsA==",
+      "requires": {
+        "@webex/common": "1.61.1",
+        "@webex/common-timers": "1.61.1",
+        "@webex/internal-plugin-locus": "1.61.1",
+        "@webex/internal-plugin-metrics": "1.61.1",
+        "@webex/media-engine-webrtc": "1.61.1",
+        "@webex/plugin-people": "1.61.1",
+        "@webex/webex-core": "1.61.1",
+        "ampersand-collection": "^2.0.2",
+        "ampersand-collection-lodash-mixin": "^4.0.0",
+        "ampersand-state": "^5.0.2",
+        "babel-runtime": "^6.23.0",
+        "detectrtc": "^1.3.4",
+        "envify": "^4.1.0",
+        "lodash": "^4.17.11",
+        "lodash-decorators": "^4.3.4",
+        "sdp-transform": "^2.4.0",
+        "uuid": "^3.2.1"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+        },
+        "uuid": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+        }
+      }
+    },
+    "@webex/plugin-rooms": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-rooms/-/plugin-rooms-1.61.1.tgz",
+      "integrity": "sha512-71dkTP0B6A6fXM1J2KGAcnAdNB4F9Ta/t629CepzeXn8f86R/X/IPLCH7vVe56X/CBciA4whN31Ttbaeh4DLrw==",
+      "requires": {
+        "@webex/common": "1.61.1",
+        "@webex/internal-plugin-conversation": "1.61.1",
+        "@webex/internal-plugin-mercury": "1.61.1",
+        "@webex/webex-core": "1.61.1",
+        "babel-runtime": "^6.23.0",
+        "debug": "^3.1.0",
+        "envify": "^4.1.0",
+        "lodash": "^4.17.11"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
+    },
+    "@webex/plugin-team-memberships": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-team-memberships/-/plugin-team-memberships-1.61.1.tgz",
+      "integrity": "sha512-tsl32O4qz5tgmbGDeWjbRlWD3sXeswP54hgLWQfuoEsqL41M5Lg6dwsmomsl1+Llw+rYqqalBpbKtDb1eDLhDg==",
+      "requires": {
+        "@webex/webex-core": "1.61.1",
+        "envify": "^4.1.0"
+      }
+    },
+    "@webex/plugin-teams": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-teams/-/plugin-teams-1.61.1.tgz",
+      "integrity": "sha512-7rkHn5kRqN91H9WYe0zfrPmfBr5gCzAtj0Tf0TYWVqZDnrr26FzPdOB1gxfYWBTmzZzUsR8YvoFATgleUzyqxA==",
+      "requires": {
+        "@webex/webex-core": "1.61.1",
+        "envify": "^4.1.0"
+      }
+    },
+    "@webex/plugin-webhooks": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-webhooks/-/plugin-webhooks-1.61.1.tgz",
+      "integrity": "sha512-rf1SeScuUzLaacDBI4TiKk+59fdDezxjDHye1eoD/dRBO98zZjOkh05GWwZkXwN5lBaLU8kuMkhpA2q04ypUug==",
+      "requires": {
+        "@webex/webex-core": "1.61.1",
+        "envify": "^4.1.0"
+      }
+    },
+    "@webex/storage-adapter-local-storage": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@webex/storage-adapter-local-storage/-/storage-adapter-local-storage-1.61.1.tgz",
+      "integrity": "sha512-7/+0eXMIHp95VpSuqMZFGoMQYUcP/P7h8Hd/H7jU+wC7OfnkSTNqxa96q8Txha0GtreBr/w+yeuDD+5+F1O+Zw==",
+      "requires": {
+        "@webex/webex-core": "1.61.1",
+        "babel-runtime": "^6.23.0",
+        "envify": "^4.1.0"
+      }
+    },
+    "@webex/webex-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@webex/webex-core/-/webex-core-1.61.1.tgz",
+      "integrity": "sha512-JSG7j/+WPSn/rZ/s5Ej1KlITKDYxn358SpWMAR416FZkEbo5PNaUJANwsO1exGw87rGmKAWbJE/i22OdtMvMgA==",
+      "requires": {
+        "@webex/common": "1.61.1",
+        "@webex/common-timers": "1.61.1",
+        "@webex/http-core": "1.61.1",
+        "@webex/webex-core": "1.61.1",
+        "ampersand-collection": "^2.0.2",
+        "ampersand-events": "^2.0.2",
+        "ampersand-state": "^5.0.2",
+        "babel-runtime": "^6.23.0",
+        "core-decorators": "^0.20.0",
+        "envify": "^4.1.0",
+        "lodash": "^4.17.11",
+        "uuid": "^3.2.1"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+        },
+        "uuid": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+        }
+      }
+    },
     "acorn": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
@@ -16,7 +749,18 @@
       "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
       "dev": true,
       "requires": {
-        "acorn": "3.3.0"
+        "acorn": "^3.0.4"
+      }
+    },
+    "ajv": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
+      "integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
+      "requires": {
+        "fast-deep-equal": "^2.0.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
       }
     },
     "align-text": {
@@ -24,10 +768,11 @@
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
+      "optional": true,
       "requires": {
-        "kind-of": "3.2.2",
-        "longest": "1.0.1",
-        "repeat-string": "1.6.1"
+        "kind-of": "^3.0.2",
+        "longest": "^1.0.1",
+        "repeat-string": "^1.5.2"
       }
     },
     "amdefine": {
@@ -36,13 +781,71 @@
       "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
       "dev": true
     },
+    "ampersand-class-extend": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ampersand-class-extend/-/ampersand-class-extend-2.0.0.tgz",
+      "integrity": "sha1-Uolf+lkhdjSmGI/RhLEEj12Aiv8=",
+      "requires": {
+        "lodash": "^4.11.1"
+      }
+    },
+    "ampersand-collection": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/ampersand-collection/-/ampersand-collection-2.0.2.tgz",
+      "integrity": "sha512-IjDa4HTL/tdQDDL0SGyWk4AHD02iNtUSLRWkAsJ2biPvapljW9HNgIEIdbPnnR+7Gb9BJkjesaLNjVZfAMzeuA==",
+      "requires": {
+        "ampersand-class-extend": "^2.0.0",
+        "ampersand-events": "^2.0.1",
+        "ampersand-version": "^1.0.2",
+        "lodash": "^4.11.1"
+      }
+    },
+    "ampersand-collection-lodash-mixin": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/ampersand-collection-lodash-mixin/-/ampersand-collection-lodash-mixin-4.0.0.tgz",
+      "integrity": "sha1-DtBHqOc8sHC8NrZ4pGPjgqyNtt0=",
+      "requires": {
+        "ampersand-version": "^1.0.0",
+        "lodash": "^4.6.1"
+      }
+    },
+    "ampersand-events": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/ampersand-events/-/ampersand-events-2.0.2.tgz",
+      "integrity": "sha1-9AK8LhgwX6vZldvc07cFe73X00c=",
+      "requires": {
+        "ampersand-version": "^1.0.2",
+        "lodash": "^4.6.1"
+      }
+    },
+    "ampersand-state": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/ampersand-state/-/ampersand-state-5.0.3.tgz",
+      "integrity": "sha512-sr904K5zvw6mkGjFHhTcfBIdpoJ6mn/HrFg7OleRmBpw3apLb3Z0gVrgRTb7kK1wOLI34vs4S+IXqNHUeqWCzw==",
+      "requires": {
+        "ampersand-events": "^2.0.1",
+        "ampersand-version": "^1.0.0",
+        "array-next": "~0.0.1",
+        "key-tree-store": "^1.3.0",
+        "lodash": "^4.12.0"
+      }
+    },
+    "ampersand-version": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/ampersand-version/-/ampersand-version-1.0.2.tgz",
+      "integrity": "sha1-/489TOrE0yzNg/a9Zpc5f3tZ4sA=",
+      "requires": {
+        "find-root": "^0.1.1",
+        "through2": "^0.6.3"
+      }
+    },
     "anchor-markdown-header": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/anchor-markdown-header/-/anchor-markdown-header-0.5.7.tgz",
       "integrity": "sha1-BFBj125qH5zTJ6V6ASaqD97Dcac=",
       "dev": true,
       "requires": {
-        "emoji-regex": "6.1.3"
+        "emoji-regex": "~6.1.0"
       }
     },
     "ansi-escape-sequences": {
@@ -51,7 +854,7 @@
       "integrity": "sha1-HBg5S2r5t2/5pjUJ+kl2af0s5T4=",
       "dev": true,
       "requires": {
-        "array-back": "1.0.4"
+        "array-back": "^1.0.3"
       },
       "dependencies": {
         "array-back": {
@@ -60,7 +863,7 @@
           "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
           "dev": true,
           "requires": {
-            "typical": "2.6.1"
+            "typical": "^2.6.0"
           }
         }
       }
@@ -81,8 +884,23 @@
       "integrity": "sha512-eJv4pLLufP3g5kcZry0j6WXpIbzYw9GUB4mVJZno9wfwiBxbizTnHCw3VJb07cBihbFX48Y7oSrW9y+gt4glyw==",
       "dev": true,
       "requires": {
-        "typical": "2.6.1"
+        "typical": "^2.6.1"
       }
+    },
+    "array-next": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/array-next/-/array-next-0.0.1.tgz",
+      "integrity": "sha1-5eRmCkwn/agVH/d2QnXQCQAGK+E="
+    },
+    "array-parallel": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/array-parallel/-/array-parallel-0.1.3.tgz",
+      "integrity": "sha1-j3hTCJJu1apHjEfmTRszS2wMlH0="
+    },
+    "array-series": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/array-series/-/array-series-0.1.5.tgz",
+      "integrity": "sha1-3103v8XC7wdV4qpPkv6ufUtaly8="
     },
     "asn1": {
       "version": "0.2.3",
@@ -99,8 +917,18 @@
       "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
       "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
       "requires": {
-        "lodash": "4.17.4"
+        "lodash": "^4.14.0"
       }
+    },
+    "async-limiter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
+      "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "aws-sign2": {
       "version": "0.6.0",
@@ -111,6 +939,45 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
       "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
+    },
+    "b64u": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/b64u/-/b64u-2.0.0.tgz",
+      "integrity": "sha512-N3SnhKhQtwm9a4+rdNT0JvnNdPlRwpQZN4tfJwOE3/qJVzM+OlYj/Iz2n1S3KXAQmKHaRwWUNW5gEnjuD8cXHg=="
+    },
+    "babel-polyfill": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
+      "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
+      "requires": {
+        "babel-runtime": "^6.26.0",
+        "core-js": "^2.5.0",
+        "regenerator-runtime": "^0.10.5"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.10.5",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+          "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
+        }
+      }
+    },
+    "babel-runtime": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "requires": {
+        "core-js": "^2.4.0",
+        "regenerator-runtime": "^0.11.0"
+      }
+    },
+    "backoff": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/backoff/-/backoff-2.5.0.tgz",
+      "integrity": "sha1-9hbtqdPktmuMp/ynn2lXIsX44m8=",
+      "requires": {
+        "precond": "0.2"
+      }
     },
     "bail": {
       "version": "1.0.2",
@@ -130,7 +997,7 @@
       "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
       "optional": true,
       "requires": {
-        "tweetnacl": "0.14.5"
+        "tweetnacl": "^0.14.3"
       }
     },
     "bl": {
@@ -138,7 +1005,7 @@
       "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
       "integrity": "sha1-/cqHGplxOqANGeO7ukHER4emU5g=",
       "requires": {
-        "readable-stream": "2.0.6"
+        "readable-stream": "~2.0.5"
       }
     },
     "bluebird": {
@@ -152,7 +1019,7 @@
       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
       "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
       "requires": {
-        "hoek": "2.16.3"
+        "hoek": "2.x.x"
       }
     },
     "bottleneck": {
@@ -166,13 +1033,18 @@
       "integrity": "sha1-TWfcJgLAzBbdm85+v4fpSCkPWBI=",
       "dev": true
     },
+    "bowser": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-1.9.4.tgz",
+      "integrity": "sha512-9IdMmj2KjigRq6oWhmwv1W36pDuA4STQZ8q6YO9um+x07xgYNCD3Oou+WP/3L1HNz7iqythGet3/p4wvc8AAwQ=="
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -182,9 +1054,9 @@
       "integrity": "sha512-4TgWfe9SF+bUy5cCql8gWHqKNrviufNwSYxLjf2utB0pY4+bdcuFwMmY1hDB+67Gz/L1vmhFNhePAjJTFBtV+Q==",
       "dev": true,
       "requires": {
-        "array-back": "2.0.0",
-        "fs-then-native": "2.0.0",
-        "mkdirp2": "1.0.3"
+        "array-back": "^2.0.0",
+        "fs-then-native": "^2.0.0",
+        "mkdirp2": "^1.0.3"
       }
     },
     "camelcase": {
@@ -205,7 +1077,7 @@
       "integrity": "sha1-mMyJDKZS3S7w5ws3klMQ/56Q/Is=",
       "dev": true,
       "requires": {
-        "underscore-contrib": "0.3.0"
+        "underscore-contrib": "~0.3.0"
       }
     },
     "ccount": {
@@ -221,8 +1093,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "align-text": "0.1.4",
-        "lazy-cache": "1.0.4"
+        "align-text": "^0.1.3",
+        "lazy-cache": "^1.0.3"
       }
     },
     "chalk": {
@@ -230,11 +1102,11 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "requires": {
-        "ansi-styles": "2.2.1",
-        "escape-string-regexp": "1.0.5",
-        "has-ansi": "2.0.0",
-        "strip-ansi": "3.0.1",
-        "supports-color": "2.0.0"
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
       }
     },
     "character-entities": {
@@ -268,8 +1140,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "center-align": "0.1.3",
-        "right-align": "0.1.3",
+        "center-align": "^0.1.1",
+        "right-align": "^0.1.1",
         "wordwrap": "0.0.2"
       },
       "dependencies": {
@@ -294,8 +1166,8 @@
       "integrity": "sha512-0y0rBgoX8IzIjBAUnO73SEtSb4Mhk3IoceWJq5zZSxb9mWORhWH8xLYo4EDSOE1jRBk1LhmfjqWFFt10h/+MEA==",
       "dev": true,
       "requires": {
-        "stream-connect": "1.0.2",
-        "stream-via": "1.0.4"
+        "stream-connect": "^1.0.2",
+        "stream-via": "^1.0.4"
       }
     },
     "combined-stream": {
@@ -303,7 +1175,7 @@
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
       "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
       "requires": {
-        "delayed-stream": "1.0.0"
+        "delayed-stream": "~1.0.0"
       }
     },
     "command-line-args": {
@@ -312,9 +1184,9 @@
       "integrity": "sha512-aUdPvQRAyBvQd2n7jXcsMDz68ckBJELXNzBybCHOibUWEg0mWTnaYCSRU8h9R+aNRSvDihJtssSRCiDRpLaezA==",
       "dev": true,
       "requires": {
-        "array-back": "2.0.0",
-        "find-replace": "1.0.3",
-        "typical": "2.6.1"
+        "array-back": "^2.0.0",
+        "find-replace": "^1.0.3",
+        "typical": "^2.6.1"
       }
     },
     "command-line-tool": {
@@ -323,11 +1195,11 @@
       "integrity": "sha1-yoB5KuIGnPfKpWLAy8LNEYERIqA=",
       "dev": true,
       "requires": {
-        "ansi-escape-sequences": "3.0.0",
-        "array-back": "1.0.4",
-        "command-line-args": "4.0.7",
-        "command-line-usage": "4.1.0",
-        "typical": "2.6.1"
+        "ansi-escape-sequences": "^3.0.0",
+        "array-back": "^1.0.4",
+        "command-line-args": "^4.0.1",
+        "command-line-usage": "^4.0.0",
+        "typical": "^2.6.0"
       },
       "dependencies": {
         "array-back": {
@@ -336,7 +1208,7 @@
           "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
           "dev": true,
           "requires": {
-            "typical": "2.6.1"
+            "typical": "^2.6.0"
           }
         }
       }
@@ -347,10 +1219,10 @@
       "integrity": "sha512-MxS8Ad995KpdAC0Jopo/ovGIroV/m0KHwzKfXxKag6FHOkGsH8/lv5yjgablcRxCJJC0oJeUMuO/gmaq+Wq46g==",
       "dev": true,
       "requires": {
-        "ansi-escape-sequences": "4.0.0",
-        "array-back": "2.0.0",
-        "table-layout": "0.4.3",
-        "typical": "2.6.1"
+        "ansi-escape-sequences": "^4.0.0",
+        "array-back": "^2.0.0",
+        "table-layout": "^0.4.2",
+        "typical": "^2.6.1"
       },
       "dependencies": {
         "ansi-escape-sequences": {
@@ -359,7 +1231,7 @@
           "integrity": "sha512-v+0wW9Wezwsyb0uF4aBVCjmSqit3Ru7PZFziGF0o2KwTvN2zWfTi3BRLq9EkJFdg3eBbyERXGTntVpBxH1J68Q==",
           "dev": true,
           "requires": {
-            "array-back": "2.0.0"
+            "array-back": "^2.0.0"
           }
         }
       }
@@ -387,7 +1259,7 @@
       "integrity": "sha1-ZnZjWQUFooO/JqSE1oSJ10xUhdo=",
       "dev": true,
       "requires": {
-        "walk-back": "2.0.1"
+        "walk-back": "^2.0.1"
       },
       "dependencies": {
         "walk-back": {
@@ -398,17 +1270,36 @@
         }
       }
     },
+    "core-decorators": {
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/core-decorators/-/core-decorators-0.20.0.tgz",
+      "integrity": "sha1-YFiWYkBTr4wo775zXCWjAaYcZcU="
+    },
+    "core-js": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
+      "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A=="
+    },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "cross-spawn": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
+      "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
+      "requires": {
+        "lru-cache": "^4.0.1",
+        "which": "^1.2.9"
+      }
     },
     "cryptiles": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
       "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
       "requires": {
-        "boom": "2.10.1"
+        "boom": "2.x.x"
       }
     },
     "dashdash": {
@@ -416,7 +1307,7 @@
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       },
       "dependencies": {
         "assert-plus": {
@@ -447,10 +1338,23 @@
       "integrity": "sha1-bvSgmwX5iw41jW2T1Mo8rsZnKAM=",
       "dev": true
     },
+    "define-properties": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "requires": {
+        "object-keys": "^1.0.12"
+      }
+    },
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
+    "detectrtc": {
+      "version": "1.3.9",
+      "resolved": "https://registry.npmjs.org/detectrtc/-/detectrtc-1.3.9.tgz",
+      "integrity": "sha512-uDmANQib8St/dRppyQGXHX36qG2wel5dKHslqz0qr2958rcpN6heOzofV2PoKi7ogtCXpQuz0JUzazWhnLBPcA=="
     },
     "dmd": {
       "version": "3.0.11",
@@ -458,18 +1362,18 @@
       "integrity": "sha512-Naq/y7ME1dG8e4u0IJ2jA/G2gtbm4ZQzAG0LldwE1BCUrVWzR9VY5ayvXYSd+p9fdh5ojxayABbelDRM32xIhg==",
       "dev": true,
       "requires": {
-        "array-back": "2.0.0",
-        "cache-point": "0.4.1",
-        "common-sequence": "1.0.2",
-        "file-set": "2.0.0",
-        "handlebars": "4.0.11",
-        "marked": "0.3.17",
-        "object-get": "2.1.0",
-        "reduce-flatten": "1.0.1",
-        "reduce-unique": "1.0.0",
-        "reduce-without": "1.0.1",
-        "test-value": "3.0.0",
-        "walk-back": "3.0.0"
+        "array-back": "^2.0.0",
+        "cache-point": "^0.4.1",
+        "common-sequence": "^1.0.2",
+        "file-set": "^2.0.0",
+        "handlebars": "^4.0.11",
+        "marked": "^0.3.16",
+        "object-get": "^2.1.0",
+        "reduce-flatten": "^1.0.1",
+        "reduce-unique": "^1.0.0",
+        "reduce-without": "^1.0.1",
+        "test-value": "^3.0.0",
+        "walk-back": "^3.0.0"
       },
       "dependencies": {
         "test-value": {
@@ -478,8 +1382,8 @@
           "integrity": "sha512-sVACdAWcZkSU9x7AOmJo5TqE+GyNJknHaHsMrR6ZnhjVlVN9Yx6FjHrsKZ3BjIpPCT68zYesPWkakrNupwfOTQ==",
           "dev": true,
           "requires": {
-            "array-back": "2.0.0",
-            "typical": "2.6.1"
+            "array-back": "^2.0.0",
+            "typical": "^2.6.1"
           }
         }
       }
@@ -490,12 +1394,12 @@
       "integrity": "sha1-8BLjYD4xViVMLvIqyIxxkPVUJro=",
       "dev": true,
       "requires": {
-        "anchor-markdown-header": "0.5.7",
-        "htmlparser2": "3.9.2",
-        "markdown-to-ast": "3.4.0",
-        "minimist": "1.2.0",
-        "underscore": "1.8.3",
-        "update-section": "0.3.3"
+        "anchor-markdown-header": "^0.5.5",
+        "htmlparser2": "~3.9.2",
+        "markdown-to-ast": "~3.4.0",
+        "minimist": "~1.2.0",
+        "underscore": "~1.8.3",
+        "update-section": "^0.3.0"
       }
     },
     "dom-serializer": {
@@ -504,8 +1408,8 @@
       "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
       "dev": true,
       "requires": {
-        "domelementtype": "1.1.3",
-        "entities": "1.1.1"
+        "domelementtype": "~1.1.1",
+        "entities": "~1.1.1"
       },
       "dependencies": {
         "domelementtype": {
@@ -515,6 +1419,11 @@
           "dev": true
         }
       }
+    },
+    "dom-walk": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz",
+      "integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg="
     },
     "domelementtype": {
       "version": "1.3.0",
@@ -528,7 +1437,7 @@
       "integrity": "sha1-iS5HAAqZvlW783dP/qBWHYh5wlk=",
       "dev": true,
       "requires": {
-        "domelementtype": "1.3.0"
+        "domelementtype": "1"
       }
     },
     "domutils": {
@@ -537,8 +1446,8 @@
       "integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
       "dev": true,
       "requires": {
-        "dom-serializer": "0.1.0",
-        "domelementtype": "1.3.0"
+        "dom-serializer": "0",
+        "domelementtype": "1"
       }
     },
     "double-ended-queue": {
@@ -552,7 +1461,7 @@
       "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
       "optional": true,
       "requires": {
-        "jsbn": "0.1.1"
+        "jsbn": "~0.1.0"
       }
     },
     "emoji-regex": {
@@ -567,6 +1476,53 @@
       "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA=",
       "dev": true
     },
+    "envify": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/envify/-/envify-4.1.0.tgz",
+      "integrity": "sha512-IKRVVoAYr4pIx4yIWNsz9mOsboxlNXiu7TNBnem/K/uTHdkyzXWDzHCK7UTolqBbgaBz0tQHsD3YNls0uIIjiw==",
+      "requires": {
+        "esprima": "^4.0.0",
+        "through": "~2.3.4"
+      }
+    },
+    "es-abstract": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
+      "integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
+      "requires": {
+        "es-to-primitive": "^1.2.0",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "is-callable": "^1.1.4",
+        "is-regex": "^1.0.4",
+        "object-keys": "^1.0.12"
+      },
+      "dependencies": {
+        "has": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+          "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+          "requires": {
+            "function-bind": "^1.1.1"
+          }
+        }
+      }
+    },
+    "es-to-primitive": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
+      "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
+      "requires": {
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
+      }
+    },
+    "es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
+    },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
@@ -578,8 +1534,21 @@
       "integrity": "sha1-/V3ux2qXpRIKnNOnyxF3oJI7EdI=",
       "dev": true,
       "requires": {
-        "acorn": "3.3.0",
-        "acorn-jsx": "3.0.1"
+        "acorn": "^3.3.0",
+        "acorn-jsx": "^3.0.0"
+      }
+    },
+    "esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+    },
+    "exif": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/exif/-/exif-0.6.0.tgz",
+      "integrity": "sha1-YKYmaAdlQst+T1cZnUrG830sX0o=",
+      "requires": {
+        "debug": "^2.2"
       }
     },
     "extend": {
@@ -592,15 +1561,30 @@
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
     },
+    "fast-deep-equal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+    },
     "file-set": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/file-set/-/file-set-2.0.0.tgz",
       "integrity": "sha512-cCWXfw+nrYoIoUVmEF7Xsw91lGWuObtSnTEZ7AmdvZou1A/6Xx237HfxdQyC/ayKRvQSMbNOBwg62OjN5JxbXw==",
       "dev": true,
       "requires": {
-        "array-back": "2.0.0",
-        "glob": "7.1.2"
+        "array-back": "^2.0.0",
+        "glob": "^7.1.2"
       }
+    },
+    "file-type": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
+      "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek="
     },
     "find-replace": {
       "version": "1.0.3",
@@ -608,8 +1592,8 @@
       "integrity": "sha1-uI5zZNLZyVlVnziMZmcNYTBEH6A=",
       "dev": true,
       "requires": {
-        "array-back": "1.0.4",
-        "test-value": "2.1.0"
+        "array-back": "^1.0.4",
+        "test-value": "^2.1.0"
       },
       "dependencies": {
         "array-back": {
@@ -618,9 +1602,22 @@
           "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
           "dev": true,
           "requires": {
-            "typical": "2.6.1"
+            "typical": "^2.6.0"
           }
         }
+      }
+    },
+    "find-root": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/find-root/-/find-root-0.1.2.tgz",
+      "integrity": "sha1-mNImfP8ZFsyvJ0OzoO6oHXnX3NE="
+    },
+    "for-each": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+      "requires": {
+        "is-callable": "^1.1.3"
       }
     },
     "forever-agent": {
@@ -633,9 +1630,9 @@
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.1.tgz",
       "integrity": "sha1-rjFduaSQf6BlUCMEpm13M0de43w=",
       "requires": {
-        "async": "2.6.0",
-        "combined-stream": "1.0.6",
-        "mime-types": "2.1.15"
+        "async": "^2.0.1",
+        "combined-stream": "^1.0.5",
+        "mime-types": "^2.1.11"
       }
     },
     "fs-then-native": {
@@ -653,8 +1650,7 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "generate-function": {
       "version": "2.0.0",
@@ -666,7 +1662,7 @@
       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
       "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
       "requires": {
-        "is-property": "1.0.2"
+        "is-property": "^1.0.0"
       }
     },
     "getpass": {
@@ -674,7 +1670,7 @@
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       },
       "dependencies": {
         "assert-plus": {
@@ -690,12 +1686,47 @@
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "dev": true,
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "global": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/global/-/global-4.4.0.tgz",
+      "integrity": "sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==",
+      "requires": {
+        "min-document": "^2.19.0",
+        "process": "^0.11.10"
+      }
+    },
+    "gm": {
+      "version": "1.23.1",
+      "resolved": "https://registry.npmjs.org/gm/-/gm-1.23.1.tgz",
+      "integrity": "sha1-Lt7rlYCE0PjqeYjl2ZWxx9/BR3c=",
+      "requires": {
+        "array-parallel": "~0.1.3",
+        "array-series": "~0.1.5",
+        "cross-spawn": "^4.0.0",
+        "debug": "^3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
       }
     },
     "graceful-fs": {
@@ -711,10 +1742,10 @@
       "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
       "dev": true,
       "requires": {
-        "async": "1.5.2",
-        "optimist": "0.6.1",
-        "source-map": "0.4.4",
-        "uglify-js": "2.8.29"
+        "async": "^1.4.0",
+        "optimist": "^0.6.1",
+        "source-map": "^0.4.4",
+        "uglify-js": "^2.6"
       },
       "dependencies": {
         "async": {
@@ -725,24 +1756,28 @@
         }
       }
     },
+    "har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+    },
     "har-validator": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
       "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
       "requires": {
-        "chalk": "1.1.3",
-        "commander": "2.15.0",
-        "is-my-json-valid": "2.17.2",
-        "pinkie-promise": "2.0.1"
+        "chalk": "^1.1.1",
+        "commander": "^2.9.0",
+        "is-my-json-valid": "^2.12.4",
+        "pinkie-promise": "^2.0.0"
       }
     },
     "has": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
       "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
-      "dev": true,
       "requires": {
-        "function-bind": "1.1.1"
+        "function-bind": "^1.0.2"
       }
     },
     "has-ansi": {
@@ -750,18 +1785,23 @@
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
+    },
+    "has-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
+      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q="
     },
     "hawk": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
       "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
       "requires": {
-        "boom": "2.10.1",
-        "cryptiles": "2.0.5",
-        "hoek": "2.16.3",
-        "sntp": "1.0.9"
+        "boom": "2.x.x",
+        "cryptiles": "2.x.x",
+        "hoek": "2.x.x",
+        "sntp": "1.x.x"
       }
     },
     "hoek": {
@@ -775,12 +1815,12 @@
       "integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
       "dev": true,
       "requires": {
-        "domelementtype": "1.3.0",
-        "domhandler": "2.4.1",
-        "domutils": "1.7.0",
-        "entities": "1.1.1",
-        "inherits": "2.0.3",
-        "readable-stream": "2.0.6"
+        "domelementtype": "^1.3.0",
+        "domhandler": "^2.3.0",
+        "domutils": "^1.5.1",
+        "entities": "^1.1.1",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.2"
       }
     },
     "http-signature": {
@@ -788,9 +1828,9 @@
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
       "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
       "requires": {
-        "assert-plus": "0.2.0",
-        "jsprim": "1.4.1",
-        "sshpk": "1.14.1"
+        "assert-plus": "^0.2.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
       }
     },
     "inflight": {
@@ -799,8 +1839,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -820,21 +1860,37 @@
       "integrity": "sha1-37SqTRCF4zvbYcLe6cgOnGwZ9Ts=",
       "dev": true,
       "requires": {
-        "is-alphabetical": "1.0.1",
-        "is-decimal": "1.0.1"
+        "is-alphabetical": "^1.0.0",
+        "is-decimal": "^1.0.0"
       }
     },
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true
+      "dev": true,
+      "optional": true
+    },
+    "is-callable": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
+      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA=="
+    },
+    "is-date-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
     },
     "is-decimal": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.1.tgz",
       "integrity": "sha1-9ftqlJlq2ejjdh+/vQkfH8qMToI=",
       "dev": true
+    },
+    "is-function": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.1.tgz",
+      "integrity": "sha1-Es+5i2W1fdPRk6MSH19uL0N2ArU="
     },
     "is-hexadecimal": {
       "version": "1.0.1",
@@ -852,17 +1908,33 @@
       "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.17.2.tgz",
       "integrity": "sha512-IBhBslgngMQN8DDSppmgDv7RNrlFotuuDsKcrCP3+HbFaVivIBU7u9oiiErw8sH4ynx3+gOGQ3q2otkgiSi6kg==",
       "requires": {
-        "generate-function": "2.0.0",
-        "generate-object-property": "1.2.0",
-        "is-my-ip-valid": "1.0.0",
-        "jsonpointer": "4.0.1",
-        "xtend": "4.0.1"
+        "generate-function": "^2.0.0",
+        "generate-object-property": "^1.1.0",
+        "is-my-ip-valid": "^1.0.0",
+        "jsonpointer": "^4.0.0",
+        "xtend": "^4.0.0"
       }
     },
     "is-property": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
       "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ="
+    },
+    "is-regex": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "requires": {
+        "has": "^1.0.1"
+      }
+    },
+    "is-symbol": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
+      "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+      "requires": {
+        "has-symbols": "^1.0.0"
+      }
     },
     "is-typedarray": {
       "version": "1.0.0",
@@ -873,6 +1945,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
     "isstream": {
       "version": "0.1.2",
@@ -897,18 +1974,18 @@
       "integrity": "sha1-qAcRlSi0AJzLyrSbdSL2P+xs0L0=",
       "dev": true,
       "requires": {
-        "bluebird": "3.4.7",
-        "catharsis": "0.8.9",
-        "escape-string-regexp": "1.0.5",
-        "espree": "3.1.7",
-        "js2xmlparser": "1.0.0",
-        "klaw": "1.3.1",
-        "marked": "0.3.17",
-        "mkdirp": "0.5.1",
-        "requizzle": "0.2.1",
-        "strip-json-comments": "2.0.1",
+        "bluebird": "~3.4.6",
+        "catharsis": "~0.8.8",
+        "escape-string-regexp": "~1.0.5",
+        "espree": "~3.1.7",
+        "js2xmlparser": "~1.0.0",
+        "klaw": "~1.3.0",
+        "marked": "~0.3.6",
+        "mkdirp": "~0.5.1",
+        "requizzle": "~0.2.1",
+        "strip-json-comments": "~2.0.1",
         "taffydb": "2.6.2",
-        "underscore": "1.8.3"
+        "underscore": "~1.8.3"
       }
     },
     "jsdoc-api": {
@@ -917,15 +1994,15 @@
       "integrity": "sha1-DVJwAjX4Zb1Ki61evB77Vi/IrSo=",
       "dev": true,
       "requires": {
-        "array-back": "1.0.4",
-        "cache-point": "0.4.1",
-        "collect-all": "1.0.3",
-        "file-set": "1.1.1",
-        "fs-then-native": "2.0.0",
-        "jsdoc-75lb": "3.6.0",
-        "object-to-spawn-args": "1.1.1",
-        "temp-path": "1.0.0",
-        "walk-back": "2.0.1"
+        "array-back": "^1.0.4",
+        "cache-point": "~0.4.0",
+        "collect-all": "^1.0.2",
+        "file-set": "^1.1.1",
+        "fs-then-native": "^2.0.0",
+        "jsdoc-75lb": "^3.6.0",
+        "object-to-spawn-args": "^1.1.0",
+        "temp-path": "^1.0.0",
+        "walk-back": "^2.0.1"
       },
       "dependencies": {
         "array-back": {
@@ -934,7 +2011,7 @@
           "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
           "dev": true,
           "requires": {
-            "typical": "2.6.1"
+            "typical": "^2.6.0"
           }
         },
         "file-set": {
@@ -943,8 +2020,8 @@
           "integrity": "sha1-0+xwwIDsjxjyBLod4QZ4DJBWkms=",
           "dev": true,
           "requires": {
-            "array-back": "1.0.4",
-            "glob": "7.1.2"
+            "array-back": "^1.0.3",
+            "glob": "^7.1.0"
           }
         },
         "walk-back": {
@@ -961,12 +2038,12 @@
       "integrity": "sha512-btZLp4wYl90vcAfgk4hoGQbO17iBVrhh3LJRMKZNtZgniO3F8H2CjxXld0owBIB1XxN+j3bAcWZnZKMnSj3iMA==",
       "dev": true,
       "requires": {
-        "array-back": "2.0.0",
-        "lodash.omit": "4.5.0",
-        "lodash.pick": "4.4.0",
-        "reduce-extract": "1.0.0",
-        "sort-array": "2.0.0",
-        "test-value": "3.0.0"
+        "array-back": "^2.0.0",
+        "lodash.omit": "^4.5.0",
+        "lodash.pick": "^4.4.0",
+        "reduce-extract": "^1.0.0",
+        "sort-array": "^2.0.0",
+        "test-value": "^3.0.0"
       },
       "dependencies": {
         "test-value": {
@@ -975,8 +2052,8 @@
           "integrity": "sha512-sVACdAWcZkSU9x7AOmJo5TqE+GyNJknHaHsMrR6ZnhjVlVN9Yx6FjHrsKZ3BjIpPCT68zYesPWkakrNupwfOTQ==",
           "dev": true,
           "requires": {
-            "array-back": "2.0.0",
-            "typical": "2.6.1"
+            "array-back": "^2.0.0",
+            "typical": "^2.6.1"
           }
         }
       }
@@ -987,19 +2064,24 @@
       "integrity": "sha512-NDD+dpLiF9SYJXFcYPutKi/K8pRtIHHmVyQJzUArYQCoVhNISKeIVK5Pe78mi7K5s16/Nk7EviN2xxlJJ+S5Bw==",
       "dev": true,
       "requires": {
-        "array-back": "2.0.0",
-        "command-line-tool": "0.7.0",
-        "config-master": "3.1.0",
-        "dmd": "3.0.11",
-        "jsdoc-api": "3.0.0",
-        "jsdoc-parse": "3.0.1",
-        "walk-back": "3.0.0"
+        "array-back": "^2.0.0",
+        "command-line-tool": "^0.7.0",
+        "config-master": "^3.1.0",
+        "dmd": "^3.0.9",
+        "jsdoc-api": "^3.0.0",
+        "jsdoc-parse": "^3.0.1",
+        "walk-back": "^3.0.0"
       }
     },
     "json-schema": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+    },
+    "json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
     "json-stringify-safe": {
       "version": "5.0.1",
@@ -1029,13 +2111,19 @@
         }
       }
     },
+    "key-tree-store": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/key-tree-store/-/key-tree-store-1.3.0.tgz",
+      "integrity": "sha1-XqKa/CUppCWThDfWlVtxTOapeR8="
+    },
     "kind-of": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "dev": true,
+      "optional": true,
       "requires": {
-        "is-buffer": "1.1.6"
+        "is-buffer": "^1.1.5"
       }
     },
     "klaw": {
@@ -1044,7 +2132,7 @@
       "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11"
+        "graceful-fs": "^4.1.9"
       }
     },
     "lazy-cache": {
@@ -1059,11 +2147,134 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
       "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
     },
+    "lodash-decorators": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash-decorators/-/lodash-decorators-4.5.0.tgz",
+      "integrity": "sha512-isfVBBSzzXu7Z6abY/Bit5hCbM+gPhQx/DluTPAmzUPF3KRtvLLRNBgVFUxw6B8vwTMGyQFRVqbvQBli9hsXZA==",
+      "requires": {
+        "tslib": "^1.7.1"
+      }
+    },
+    "lodash._arraycopy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz",
+      "integrity": "sha1-due3wfH7klRzdIeKVi7Qaj5Q9uE="
+    },
+    "lodash._arrayeach": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz",
+      "integrity": "sha1-urFWsqkNPxu9XGU0AzSeXlkz754="
+    },
+    "lodash._baseassign": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+      "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
+      "requires": {
+        "lodash._basecopy": "^3.0.0",
+        "lodash.keys": "^3.0.0"
+      }
+    },
+    "lodash._baseclone": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lodash._baseclone/-/lodash._baseclone-3.3.0.tgz",
+      "integrity": "sha1-MDUZv2OT/n5C802LYw73eU41Qrc=",
+      "requires": {
+        "lodash._arraycopy": "^3.0.0",
+        "lodash._arrayeach": "^3.0.0",
+        "lodash._baseassign": "^3.0.0",
+        "lodash._basefor": "^3.0.0",
+        "lodash.isarray": "^3.0.0",
+        "lodash.keys": "^3.0.0"
+      }
+    },
+    "lodash._basecopy": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY="
+    },
+    "lodash._basefor": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.3.tgz",
+      "integrity": "sha1-dVC06SGO8J+tJDQ7YSAhx5tMIMI="
+    },
+    "lodash._bindcallback": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
+      "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4="
+    },
+    "lodash._getnative": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
+    },
+    "lodash._isiterateecall": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+      "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw="
+    },
+    "lodash.assign": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
+      "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
+    },
+    "lodash.clone": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clone/-/lodash.clone-4.5.0.tgz",
+      "integrity": "sha1-GVhwRQ9aExkkeN9Lw9I9LeoZB7Y="
+    },
+    "lodash.clonedeep": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-3.0.2.tgz",
+      "integrity": "sha1-oKHkDYKl6on/WxR7hETtY9koJ9s=",
+      "requires": {
+        "lodash._baseclone": "^3.0.0",
+        "lodash._bindcallback": "^3.0.0"
+      }
+    },
+    "lodash.fill": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.fill/-/lodash.fill-3.4.0.tgz",
+      "integrity": "sha1-o8dK5kDQU63w3CB5+HIHiOi/74U="
+    },
+    "lodash.flatten": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+      "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
+    },
+    "lodash.intersection": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.intersection/-/lodash.intersection-4.4.0.tgz",
+      "integrity": "sha1-ChG6Yx0OlcI8fy9Mu5ppLtF45wU="
+    },
+    "lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
+    },
+    "lodash.isarray": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
+    },
+    "lodash.keys": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+      "requires": {
+        "lodash._getnative": "^3.0.0",
+        "lodash.isarguments": "^3.0.0",
+        "lodash.isarray": "^3.0.0"
+      }
+    },
+    "lodash.merge": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.1.tgz",
+      "integrity": "sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ=="
+    },
     "lodash.omit": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz",
-      "integrity": "sha1-brGa5aHuHdnfC5aeZs4Lf6MLXmA=",
-      "dev": true
+      "integrity": "sha1-brGa5aHuHdnfC5aeZs4Lf6MLXmA="
     },
     "lodash.padend": {
       "version": "4.6.1",
@@ -1071,23 +2282,47 @@
       "integrity": "sha1-U8y6BH0G4VjTEfRdpiX05J5vFm4=",
       "dev": true
     },
+    "lodash.partialright": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/lodash.partialright/-/lodash.partialright-4.2.1.tgz",
+      "integrity": "sha1-ATDYDoM2MmTUAHTzKbij56ihzEs="
+    },
     "lodash.pick": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
-      "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM=",
-      "dev": true
+      "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM="
+    },
+    "lodash.uniq": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+      "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
+    },
+    "long": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-3.2.0.tgz",
+      "integrity": "sha1-2CG3E4yhy1gcFymQ7xTbIAtcR0s="
     },
     "longest": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "longest-streak": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-1.0.0.tgz",
       "integrity": "sha1-0GWXxNTDG1LMsfXY+P5xSOr9aWU=",
       "dev": true
+    },
+    "lru-cache": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+      "requires": {
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
+      }
     },
     "markdown-table": {
       "version": "0.4.0",
@@ -1101,10 +2336,10 @@
       "integrity": "sha1-Diy6gTkLBUmpFT7DsNkVthwWS+c=",
       "dev": true,
       "requires": {
-        "debug": "2.6.8",
-        "remark": "5.1.0",
-        "structured-source": "3.0.2",
-        "traverse": "0.6.6"
+        "debug": "^2.1.3",
+        "remark": "^5.0.1",
+        "structured-source": "^3.0.2",
+        "traverse": "^0.6.6"
       }
     },
     "marked": {
@@ -1123,7 +2358,15 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
       "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
       "requires": {
-        "mime-db": "1.27.0"
+        "mime-db": "~1.27.0"
+      }
+    },
+    "min-document": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
+      "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
+      "requires": {
+        "dom-walk": "^0.1.0"
       }
     },
     "minimatch": {
@@ -1132,7 +2375,7 @@
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
-        "brace-expansion": "1.1.11"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -1174,6 +2417,94 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
+    "node-forge": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.6.tgz",
+      "integrity": "sha512-sol30LUpz1jQFBjOKwbjxijiE3b6pjd74YwfD0fJOKPjF+fONKb2Yg8rYgS6+bK6VDl+/wfr4IYpC7jDzLUIfw=="
+    },
+    "node-jose": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/node-jose/-/node-jose-0.11.1.tgz",
+      "integrity": "sha512-1mX5prmancKdOgMI/85uduqWNFg63traxVdun7dNNsX4AUs6HqztJhzfBlIWfSujQ8Rah9dWLGUFlXORxZvvzg==",
+      "requires": {
+        "b64u": "^2.0.0",
+        "es6-promise": "^4.0.5",
+        "lodash.assign": "^4.0.8",
+        "lodash.clone": "^4.3.2",
+        "lodash.fill": "^3.2.2",
+        "lodash.flatten": "^4.2.0",
+        "lodash.intersection": "^4.1.2",
+        "lodash.merge": "^4.3.5",
+        "lodash.omit": "^4.2.1",
+        "lodash.partialright": "^4.1.3",
+        "lodash.pick": "^4.2.0",
+        "lodash.uniq": "^4.2.1",
+        "long": "^3.1.0",
+        "node-forge": "^0.7.1",
+        "uuid": "^3.0.1"
+      }
+    },
+    "node-kms": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/node-kms/-/node-kms-0.3.2.tgz",
+      "integrity": "sha1-beflJICO7ATHf+6072SUDlDit1k=",
+      "requires": {
+        "es6-promise": "^2.0.1",
+        "lodash.clone": "^3.0.2",
+        "lodash.clonedeep": "^3.0.1",
+        "node-jose": ">=0.3.0 <1.0",
+        "uuid": "^2.0.1"
+      },
+      "dependencies": {
+        "es6-promise": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-2.3.0.tgz",
+          "integrity": "sha1-lu258v2wGZWCKyY92KratnSBgbw="
+        },
+        "lodash.clone": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/lodash.clone/-/lodash.clone-3.0.3.tgz",
+          "integrity": "sha1-hGiMc9MrWpDKJWFpY/GJJSqZcEM=",
+          "requires": {
+            "lodash._baseclone": "^3.0.0",
+            "lodash._bindcallback": "^3.0.0",
+            "lodash._isiterateecall": "^3.0.0"
+          }
+        },
+        "uuid": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
+          "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho="
+        }
+      }
+    },
+    "node-scr": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/node-scr/-/node-scr-0.2.2.tgz",
+      "integrity": "sha1-VCqtdCAQ0S5Bm1kG2lFq+d6jBdo=",
+      "requires": {
+        "es6-promise": "^2.0.1",
+        "lodash.clone": "^3.0.2",
+        "node-jose": ">=0.3.0 <1.0"
+      },
+      "dependencies": {
+        "es6-promise": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-2.3.0.tgz",
+          "integrity": "sha1-lu258v2wGZWCKyY92KratnSBgbw="
+        },
+        "lodash.clone": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/lodash.clone/-/lodash.clone-3.0.3.tgz",
+          "integrity": "sha1-hGiMc9MrWpDKJWFpY/GJJSqZcEM=",
+          "requires": {
+            "lodash._baseclone": "^3.0.0",
+            "lodash._bindcallback": "^3.0.0",
+            "lodash._isiterateecall": "^3.0.0"
+          }
+        }
+      }
+    },
     "node-sparky": {
       "version": "3.1.21",
       "resolved": "https://registry.npmjs.org/node-sparky/-/node-sparky-3.1.21.tgz",
@@ -1182,9 +2513,9 @@
         "bottleneck": "1.12.0",
         "debug": "2.2.0",
         "lodash": "4.13.1",
-        "mime-types": "2.1.15",
+        "mime-types": "^2.1.11",
         "request": "2.74.0",
-        "uuid": "2.0.3",
+        "uuid": "^2.0.2",
         "when": "3.7.7"
       },
       "dependencies": {
@@ -1229,6 +2560,11 @@
       "integrity": "sha1-ciu9tgA576R8rTxtws5RqFwCxa4=",
       "dev": true
     },
+    "object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+    },
     "object-to-spawn-args": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-to-spawn-args/-/object-to-spawn-args-1.1.1.tgz",
@@ -1241,7 +2577,7 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "optimist": {
@@ -1250,8 +2586,8 @@
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "dev": true,
       "requires": {
-        "minimist": "0.0.10",
-        "wordwrap": "0.0.3"
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
       },
       "dependencies": {
         "minimist": {
@@ -1268,12 +2604,21 @@
       "integrity": "sha1-gRLYhHExnyerrk1klksSL+ThuJA=",
       "dev": true,
       "requires": {
-        "character-entities": "1.2.1",
-        "character-entities-legacy": "1.1.1",
-        "character-reference-invalid": "1.1.1",
-        "is-alphanumerical": "1.0.1",
-        "is-decimal": "1.0.1",
-        "is-hexadecimal": "1.0.1"
+        "character-entities": "^1.0.0",
+        "character-entities-legacy": "^1.0.0",
+        "character-reference-invalid": "^1.0.0",
+        "is-alphanumerical": "^1.0.0",
+        "is-decimal": "^1.0.0",
+        "is-hexadecimal": "^1.0.0"
+      }
+    },
+    "parse-headers": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.2.tgz",
+      "integrity": "sha512-/LypJhzFmyBIDYP9aDVgeyEb5sQfbfY5mnDq4hVhlQ69js87wXfmEI5V3xI6vvXasqebp0oCytYFLxsBVfCzSg==",
+      "requires": {
+        "for-each": "^0.3.3",
+        "string.prototype.trim": "^1.1.2"
       }
     },
     "path-is-absolute": {
@@ -1281,6 +2626,11 @@
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
+    },
+    "performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "pinkie": {
       "version": "2.0.4",
@@ -1292,13 +2642,33 @@
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "requires": {
-        "pinkie": "2.0.4"
+        "pinkie": "^2.0.0"
       }
+    },
+    "precond": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/precond/-/precond-0.2.3.tgz",
+      "integrity": "sha1-qpWRvKokkj8eD0hJ0kD0fvwQdaw="
+    },
+    "process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
     },
     "process-nextick-args": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
       "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+    },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+    },
+    "psl": {
+      "version": "1.1.33",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.33.tgz",
+      "integrity": "sha512-LTDP2uSrsc7XCb5lO7A8BI1qYxRe/8EqlRvMeEl6rsnYAqDOl8xHR+8lSAIVfrNaSAlTPTNOCgNjWcoUL3AZsw=="
     },
     "punycode": {
       "version": "1.4.1",
@@ -1315,12 +2685,12 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
       "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
       "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
-        "isarray": "1.0.0",
-        "process-nextick-args": "1.0.7",
-        "string_decoder": "0.10.31",
-        "util-deprecate": "1.0.2"
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~1.0.6",
+        "string_decoder": "~0.10.x",
+        "util-deprecate": "~1.0.1"
       }
     },
     "redis": {
@@ -1328,9 +2698,9 @@
       "resolved": "https://registry.npmjs.org/redis/-/redis-2.8.0.tgz",
       "integrity": "sha512-M1OkonEQwtRmZv4tEWF2VgpG0JWJ8Fv1PhlgT5+B+uNq2cA3Rt1Yt/ryoR+vQNOQcIEgdCdfH0jr3bDpihAw1A==",
       "requires": {
-        "double-ended-queue": "2.1.0-0",
-        "redis-commands": "1.3.5",
-        "redis-parser": "2.6.0"
+        "double-ended-queue": "^2.1.0-0",
+        "redis-commands": "^1.2.0",
+        "redis-parser": "^2.6.0"
       }
     },
     "redis-commands": {
@@ -1349,7 +2719,7 @@
       "integrity": "sha1-Z/I4W+2mUGG19fQxJmLosIDKFSU=",
       "dev": true,
       "requires": {
-        "test-value": "1.1.0"
+        "test-value": "^1.0.1"
       },
       "dependencies": {
         "array-back": {
@@ -1358,7 +2728,7 @@
           "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
           "dev": true,
           "requires": {
-            "typical": "2.6.1"
+            "typical": "^2.6.0"
           }
         },
         "test-value": {
@@ -1367,8 +2737,8 @@
           "integrity": "sha1-oJE29y7AQ9J8iTcHwrFZv6196T8=",
           "dev": true,
           "requires": {
-            "array-back": "1.0.4",
-            "typical": "2.6.1"
+            "array-back": "^1.0.2",
+            "typical": "^2.4.2"
           }
         }
       }
@@ -1391,8 +2761,13 @@
       "integrity": "sha1-aK0OrRGFXJo31OglbBW7+Hly/Iw=",
       "dev": true,
       "requires": {
-        "test-value": "2.1.0"
+        "test-value": "^2.0.0"
       }
+    },
+    "regenerator-runtime": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
     },
     "remark": {
       "version": "5.1.0",
@@ -1400,9 +2775,9 @@
       "integrity": "sha1-y0Y709vLS5l5STXu4c9x16jjBow=",
       "dev": true,
       "requires": {
-        "remark-parse": "1.1.0",
-        "remark-stringify": "1.1.0",
-        "unified": "4.2.1"
+        "remark-parse": "^1.1.0",
+        "remark-stringify": "^1.1.0",
+        "unified": "^4.1.1"
       }
     },
     "remark-parse": {
@@ -1411,15 +2786,15 @@
       "integrity": "sha1-w8oQ+ajaBGFcKPCapOMEUQUm7CE=",
       "dev": true,
       "requires": {
-        "collapse-white-space": "1.0.3",
-        "extend": "3.0.1",
-        "parse-entities": "1.1.1",
-        "repeat-string": "1.6.1",
+        "collapse-white-space": "^1.0.0",
+        "extend": "^3.0.0",
+        "parse-entities": "^1.0.2",
+        "repeat-string": "^1.5.4",
         "trim": "0.0.1",
-        "trim-trailing-lines": "1.1.0",
-        "unherit": "1.1.0",
-        "unist-util-remove-position": "1.1.1",
-        "vfile-location": "2.0.2"
+        "trim-trailing-lines": "^1.0.0",
+        "unherit": "^1.0.4",
+        "unist-util-remove-position": "^1.0.0",
+        "vfile-location": "^2.0.0"
       }
     },
     "remark-stringify": {
@@ -1428,14 +2803,14 @@
       "integrity": "sha1-pxBeJbnuK/mkm3XSxCPxGwauIJI=",
       "dev": true,
       "requires": {
-        "ccount": "1.0.2",
-        "extend": "3.0.1",
-        "longest-streak": "1.0.0",
-        "markdown-table": "0.4.0",
-        "parse-entities": "1.1.1",
-        "repeat-string": "1.6.1",
-        "stringify-entities": "1.3.1",
-        "unherit": "1.1.0"
+        "ccount": "^1.0.0",
+        "extend": "^3.0.0",
+        "longest-streak": "^1.0.0",
+        "markdown-table": "^0.4.0",
+        "parse-entities": "^1.0.2",
+        "repeat-string": "^1.5.4",
+        "stringify-entities": "^1.0.1",
+        "unherit": "^1.0.4"
       }
     },
     "repeat-string": {
@@ -1449,27 +2824,27 @@
       "resolved": "https://registry.npmjs.org/request/-/request-2.74.0.tgz",
       "integrity": "sha1-dpPKdou7DqXIzgjAhKRe+gW4kqs=",
       "requires": {
-        "aws-sign2": "0.6.0",
-        "aws4": "1.6.0",
-        "bl": "1.1.2",
-        "caseless": "0.11.0",
-        "combined-stream": "1.0.6",
-        "extend": "3.0.1",
-        "forever-agent": "0.6.1",
-        "form-data": "1.0.1",
-        "har-validator": "2.0.6",
-        "hawk": "3.1.3",
-        "http-signature": "1.1.1",
-        "is-typedarray": "1.0.0",
-        "isstream": "0.1.2",
-        "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.15",
-        "node-uuid": "1.4.8",
-        "oauth-sign": "0.8.2",
-        "qs": "6.2.3",
-        "stringstream": "0.0.5",
-        "tough-cookie": "2.3.4",
-        "tunnel-agent": "0.4.3"
+        "aws-sign2": "~0.6.0",
+        "aws4": "^1.2.1",
+        "bl": "~1.1.2",
+        "caseless": "~0.11.0",
+        "combined-stream": "~1.0.5",
+        "extend": "~3.0.0",
+        "forever-agent": "~0.6.1",
+        "form-data": "~1.0.0-rc4",
+        "har-validator": "~2.0.6",
+        "hawk": "~3.1.3",
+        "http-signature": "~1.1.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.7",
+        "node-uuid": "~1.4.7",
+        "oauth-sign": "~0.8.1",
+        "qs": "~6.2.0",
+        "stringstream": "~0.0.4",
+        "tough-cookie": "~2.3.0",
+        "tunnel-agent": "~0.4.1"
       },
       "dependencies": {
         "node-uuid": {
@@ -1485,7 +2860,7 @@
       "integrity": "sha1-aUPDUwxNmn5G8c3dUcFY/GcM294=",
       "dev": true,
       "requires": {
-        "underscore": "1.6.0"
+        "underscore": "~1.6.0"
       },
       "dependencies": {
         "underscore": {
@@ -1503,15 +2878,38 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "align-text": "0.1.4"
+        "align-text": "^0.1.1"
       }
+    },
+    "rtcpeerconnection-shim": {
+      "version": "1.2.15",
+      "resolved": "https://registry.npmjs.org/rtcpeerconnection-shim/-/rtcpeerconnection-shim-1.2.15.tgz",
+      "integrity": "sha512-C6DxhXt7bssQ1nHb154lqeL0SXz5Dx4RczXZu2Aa/L1NJFnEVDxFwCBo3fqtuljhHIGceg5JKBV4XJ0gW5JKyw==",
+      "requires": {
+        "sdp": "^2.6.0"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "sdp": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/sdp/-/sdp-2.9.0.tgz",
+      "integrity": "sha512-XAVZQO4qsfzVTHorF49zCpkdxiGmPNjA8ps8RcJGtGP3QJ/A8I9/SVg/QnkAFDMXIyGbHZBBFwYBw6WdnhT96w=="
+    },
+    "sdp-transform": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/sdp-transform/-/sdp-transform-2.8.0.tgz",
+      "integrity": "sha512-0sacVJs3KzYVm89QDRiZN5eWjBidSGB4F2oYuMOhHfdiKzkZVAhh/UOG5XzjaSlrhWVHxqR7MpQe5lWA9DfsSg=="
     },
     "sntp": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
       "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
       "requires": {
-        "hoek": "2.16.3"
+        "hoek": "2.x.x"
       }
     },
     "sort-array": {
@@ -1520,9 +2918,9 @@
       "integrity": "sha1-OKnG2if9fRR7QuYFVPKBGHtN9HI=",
       "dev": true,
       "requires": {
-        "array-back": "1.0.4",
-        "object-get": "2.1.0",
-        "typical": "2.6.1"
+        "array-back": "^1.0.4",
+        "object-get": "^2.1.0",
+        "typical": "^2.6.0"
       },
       "dependencies": {
         "array-back": {
@@ -1531,7 +2929,7 @@
           "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
           "dev": true,
           "requires": {
-            "typical": "2.6.1"
+            "typical": "^2.6.0"
           }
         }
       }
@@ -1542,7 +2940,7 @@
       "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
       "dev": true,
       "requires": {
-        "amdefine": "1.0.1"
+        "amdefine": ">=0.0.4"
       }
     },
     "sshpk": {
@@ -1550,14 +2948,14 @@
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz",
       "integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
       "requires": {
-        "asn1": "0.2.3",
-        "assert-plus": "1.0.0",
-        "bcrypt-pbkdf": "1.0.1",
-        "dashdash": "1.14.1",
-        "ecc-jsbn": "0.1.1",
-        "getpass": "0.1.7",
-        "jsbn": "0.1.1",
-        "tweetnacl": "0.14.5"
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "tweetnacl": "~0.14.0"
       },
       "dependencies": {
         "assert-plus": {
@@ -1573,7 +2971,7 @@
       "integrity": "sha1-GLyB8u2zW4tdmoAJIAqYUxRCipc=",
       "dev": true,
       "requires": {
-        "array-back": "1.0.4"
+        "array-back": "^1.0.2"
       },
       "dependencies": {
         "array-back": {
@@ -1582,7 +2980,7 @@
           "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
           "dev": true,
           "requires": {
-            "typical": "2.6.1"
+            "typical": "^2.6.0"
           }
         }
       }
@@ -1592,6 +2990,16 @@
       "resolved": "https://registry.npmjs.org/stream-via/-/stream-via-1.0.4.tgz",
       "integrity": "sha512-DBp0lSvX5G9KGRDTkR/R+a29H+Wk2xItOF+MpZLLNDWbEV9tGPnqLPxHEYjmiz8xGtJHRIqmI+hCjmNzqoA4nQ==",
       "dev": true
+    },
+    "string.prototype.trim": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz",
+      "integrity": "sha1-0E3iyJ4Tf019IG8Ia17S+ua+jOo=",
+      "requires": {
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.5.0",
+        "function-bind": "^1.0.2"
+      }
     },
     "string_decoder": {
       "version": "0.10.31",
@@ -1604,10 +3012,10 @@
       "integrity": "sha1-sVDsLXKsTBtfMktR+2soyc3/BYw=",
       "dev": true,
       "requires": {
-        "character-entities-html4": "1.1.1",
-        "character-entities-legacy": "1.1.1",
-        "is-alphanumerical": "1.0.1",
-        "is-hexadecimal": "1.0.1"
+        "character-entities-html4": "^1.0.0",
+        "character-entities-legacy": "^1.0.0",
+        "is-alphanumerical": "^1.0.0",
+        "is-hexadecimal": "^1.0.0"
       }
     },
     "stringstream": {
@@ -1620,7 +3028,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "strip-json-comments": {
@@ -1635,7 +3043,7 @@
       "integrity": "sha1-3YAkJeD1PcSm56yjdSkBoczaevU=",
       "dev": true,
       "requires": {
-        "boundary": "1.0.1"
+        "boundary": "^1.0.1"
       }
     },
     "supports-color": {
@@ -1649,11 +3057,11 @@
       "integrity": "sha512-MIhflPM38ejKrFwWwC3P9x3eHvMo5G5AmNo29Qtz2HpBl5KD2GCcmOErjgNtUQLv/qaqVDagfJY3rJLPDvEgLg==",
       "dev": true,
       "requires": {
-        "array-back": "2.0.0",
-        "deep-extend": "0.5.0",
-        "lodash.padend": "4.6.1",
-        "typical": "2.6.1",
-        "wordwrapjs": "3.0.0"
+        "array-back": "^2.0.0",
+        "deep-extend": "~0.5.0",
+        "lodash.padend": "^4.6.1",
+        "typical": "^2.6.1",
+        "wordwrapjs": "^3.0.0"
       }
     },
     "taffydb": {
@@ -1674,8 +3082,8 @@
       "integrity": "sha1-Edpv9nDzRxpztiXKTz/c97t0gpE=",
       "dev": true,
       "requires": {
-        "array-back": "1.0.4",
-        "typical": "2.6.1"
+        "array-back": "^1.0.3",
+        "typical": "^2.6.0"
       },
       "dependencies": {
         "array-back": {
@@ -1684,7 +3092,39 @@
           "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
           "dev": true,
           "requires": {
-            "typical": "2.6.1"
+            "typical": "^2.6.0"
+          }
+        }
+      }
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+    },
+    "through2": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+      "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+      "requires": {
+        "readable-stream": ">=1.0.33-1 <1.1.0-0",
+        "xtend": ">=4.0.0 <4.1.0-0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
           }
         }
       }
@@ -1694,7 +3134,7 @@
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
       "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
       "requires": {
-        "punycode": "1.4.1"
+        "punycode": "^1.4.1"
       }
     },
     "traverse": {
@@ -1721,6 +3161,11 @@
       "integrity": "sha1-qf2LA5Swro//guBjOgo2zK1bX4Y=",
       "dev": true
     },
+    "tslib": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
+    },
     "tunnel-agent": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
@@ -1745,9 +3190,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "source-map": "0.5.7",
-        "uglify-to-browserify": "1.0.2",
-        "yargs": "3.10.0"
+        "source-map": "~0.5.1",
+        "uglify-to-browserify": "~1.0.0",
+        "yargs": "~3.10.0"
       },
       "dependencies": {
         "source-map": {
@@ -1795,8 +3240,8 @@
       "integrity": "sha1-a5qu379z3xdWrZ4xbdmBiFhAzX0=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "xtend": "4.0.1"
+        "inherits": "^2.0.1",
+        "xtend": "^4.0.1"
       }
     },
     "unified": {
@@ -1805,12 +3250,12 @@
       "integrity": "sha1-dv9Dqo2kMPbn5KVchOusKtLPzS4=",
       "dev": true,
       "requires": {
-        "bail": "1.0.2",
-        "extend": "3.0.1",
-        "has": "1.0.1",
-        "once": "1.4.0",
-        "trough": "1.0.1",
-        "vfile": "1.4.0"
+        "bail": "^1.0.0",
+        "extend": "^3.0.0",
+        "has": "^1.0.1",
+        "once": "^1.3.3",
+        "trough": "^1.0.0",
+        "vfile": "^1.0.0"
       }
     },
     "unist-util-is": {
@@ -1825,7 +3270,7 @@
       "integrity": "sha1-WoXBVV/BugwQG4ZwfRXlD6TIcbs=",
       "dev": true,
       "requires": {
-        "unist-util-visit": "1.3.0"
+        "unist-util-visit": "^1.1.0"
       }
     },
     "unist-util-visit": {
@@ -1834,7 +3279,7 @@
       "integrity": "sha512-9ntYcxPFtl44gnwXrQKZ5bMqXMY0ZHzUpqMFiU4zcc8mmf/jzYm8GhYgezuUlX4cJIM1zIDYaO6fG/fI+L6iiQ==",
       "dev": true,
       "requires": {
-        "unist-util-is": "2.1.1"
+        "unist-util-is": "^2.1.1"
       }
     },
     "update-section": {
@@ -1842,6 +3287,26 @@
       "resolved": "https://registry.npmjs.org/update-section/-/update-section-0.3.3.tgz",
       "integrity": "sha1-RY8Xgg03gg3GDiC4bZQ5GwASMVg=",
       "dev": true
+    },
+    "uri-js": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "requires": {
+        "punycode": "^2.1.0"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+        }
+      }
+    },
+    "urlsafe-base64": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/urlsafe-base64/-/urlsafe-base64-1.0.0.tgz",
+      "integrity": "sha1-I/iQaabGL0bPOh07ABac77kL4MY="
     },
     "util-deprecate": {
       "version": "1.0.2",
@@ -1858,9 +3323,9 @@
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "requires": {
-        "assert-plus": "1.0.0",
+        "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "1.3.0"
+        "extsprintf": "^1.2.0"
       },
       "dependencies": {
         "assert-plus": {
@@ -1888,10 +3353,57 @@
       "integrity": "sha1-I1h4ejXakQMtrV6S+AsSNw2HlcU=",
       "dev": true
     },
+    "webex": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/webex/-/webex-1.61.1.tgz",
+      "integrity": "sha512-8ArUe9N+GcCfIqG3ZLkDgdJEOvWZsasmCBvm7UB8YMWaaEohrrSFnYcSu2Js/ok3HffB2RbPohL/AOiYNw/QwA==",
+      "requires": {
+        "@webex/internal-plugin-wdm": "1.61.1",
+        "@webex/plugin-authorization": "1.61.1",
+        "@webex/plugin-logger": "1.61.1",
+        "@webex/plugin-memberships": "1.61.1",
+        "@webex/plugin-messages": "1.61.1",
+        "@webex/plugin-people": "1.61.1",
+        "@webex/plugin-phone": "1.61.1",
+        "@webex/plugin-rooms": "1.61.1",
+        "@webex/plugin-team-memberships": "1.61.1",
+        "@webex/plugin-teams": "1.61.1",
+        "@webex/plugin-webhooks": "1.61.1",
+        "@webex/storage-adapter-local-storage": "1.61.1",
+        "@webex/webex-core": "1.61.1",
+        "babel-polyfill": "^6.23.0",
+        "envify": "^4.1.0",
+        "lodash": "^4.17.11"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+        }
+      }
+    },
+    "webrtc-adapter": {
+      "version": "6.4.8",
+      "resolved": "https://registry.npmjs.org/webrtc-adapter/-/webrtc-adapter-6.4.8.tgz",
+      "integrity": "sha512-YM8yl545c/JhYcjGHgaCoA7jRK/KZuMwEDFeP2AcP0Auv5awEd+gZE0hXy9z7Ed3p9HvAXp8jdbe+4ESb1zxAw==",
+      "requires": {
+        "rtcpeerconnection-shim": "^1.2.14",
+        "sdp": "^2.9.0"
+      }
+    },
     "when": {
       "version": "3.7.8",
       "resolved": "https://registry.npmjs.org/when/-/when-3.7.8.tgz",
       "integrity": "sha1-xxMLan6gRpPoQs3J56Hyqjmjn4I="
+    },
+    "which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "requires": {
+        "isexe": "^2.0.0"
+      }
     },
     "window-size": {
       "version": "0.1.0",
@@ -1912,8 +3424,8 @@
       "integrity": "sha512-mO8XtqyPvykVCsrwj5MlOVWvSnCdT+C+QVbm6blradR7JExAhbkZ7hZ9A+9NUtwzSqrlUo9a67ws0EiILrvRpw==",
       "dev": true,
       "requires": {
-        "reduce-flatten": "1.0.1",
-        "typical": "2.6.1"
+        "reduce-flatten": "^1.0.1",
+        "typical": "^2.6.1"
       }
     },
     "wrappy": {
@@ -1922,10 +3434,24 @@
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
     },
+    "ws": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-4.1.0.tgz",
+      "integrity": "sha512-ZGh/8kF9rrRNffkLFV4AzhvooEclrOH0xaugmqGsIfFgOE/pIz4fMc4Ef+5HSQqTEug2S9JZIWDR47duDSLfaA==",
+      "requires": {
+        "async-limiter": "~1.0.0",
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "xtend": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
       "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+    },
+    "yallist": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
     },
     "yargs": {
       "version": "3.10.0",
@@ -1934,9 +3460,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "camelcase": "1.2.1",
-        "cliui": "2.1.0",
-        "decamelize": "1.2.0",
+        "camelcase": "^1.0.2",
+        "cliui": "^2.1.0",
+        "decamelize": "^1.0.0",
         "window-size": "0.1.0"
       }
     }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "node-sparky": "3.1.x",
     "redis": "2.8.x",
     "uuid": "3.1.0",
+    "webex": "^1.61.1",
     "when": "3.7.8"
   },
   "devDependencies": {


### PR DESCRIPTION
Webex (formerly ciscospark) javascript SDK now allows applications to register to listen for the message, membership and room events associated with a user via a websocket connection with the webex platform.  This approach can be used instead of traditional webhooks.

This feature allows developers who have created bots with node-flint to deploy those bots behind a firewall without requiring that the bot run with a public IP address.

To enable "websocket" mode, simply remove the webhookUrl field from the config object passed to the flint constructor